### PR TITLE
fix: included root index.md file in the release-notes collection

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -38,7 +38,7 @@ const DocsSchema = z.object({
 
 
 const releaseNotes = defineCollection({
-  loader: glob({ pattern: "**/!(**includes**)/*.md", base: "./src/content/release-notes" }),
+  loader: glob({ pattern: ["*.md", "**/!(*includes*)/*.md"], base: "./src/content/release-notes" }),
   schema: DocsSchema,
 });
 


### PR DESCRIPTION
- fixed the glob pattern to include index.md file at the root of the release-notes folder which was mistakenly excluded by the glob pattern