### PR TITLE
#152 Initial setup for contribution repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ e2e-tests/test-results/
 e2e-tests/playwright-report/
 e2e-tests/blob-report/
 e2e-tests/playwright/.cache/
+
+# External content (other GitHub repos)
+
+external-content/

--- a/README.md
+++ b/README.md
@@ -55,3 +55,17 @@ All commands are run from the root of the project, from a terminal:
 ## 👀 Want to learn more?
 
 Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).
+
+## External content
+
+The external-content folder serves as a grafting point for content residing outside the docs-next repo.
+
+To get up and running on the current code:
+
+1. Clone superoffice-docs and contribution into this folder.
+2. Add "YamlMime: SubCategory" on line 2 of contribution/index.yml. (only until the repo's we're pulling in become compliant)
+
+To bring in more of the external content when building the site:
+
+1. Define collections from this external content in src/content.config.ts
+2. Add route-building and layout for each collection in src/pages.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -13,8 +13,8 @@ import { rehypeHeadingIds } from "@astrojs/markdown-remark";
 //import rehypeSlug from 'rehype-slug';
 import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeSanitize from "rehype-sanitize";
-
 import react from "@astrojs/react";
+import yaml from '@rollup/plugin-yaml';
 
 // https://astro.build/config
 export default defineConfig({
@@ -30,6 +30,17 @@ export default defineConfig({
       ],
     ],
     // rehypeSanitize, rehypeSlug
+  },
+  vite: {
+    plugins: [yaml()]
+  },
+  content: {
+    sources: [
+      {
+        prefix: 'external',
+        include: ['./external-content/**/*.yml'],
+      },
+    ],
   },
   integrations: [
     tailwind({

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@iconify-json/mdi": "^1.1.68",
         "@iconify-json/tabler": "^1.1.119",
         "@phosphor-icons/react": "^2.1.7",
+        "@rollup/plugin-yaml": "^4.1.2",
         "@types/react": "^19.0.10",
         "@types/react-dom": "^19.0.4",
         "astro": "^5.7.11",
@@ -1998,6 +1999,68 @@
       "peerDependencies": {
         "preact": "^10.4.0",
         "vite": ">=2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-yaml": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-yaml/-/plugin-yaml-4.1.2.tgz",
+      "integrity": "sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "js-yaml": "^4.1.0",
+        "tosource": "^2.0.0-alpha.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-yaml/node_modules/@rollup/pluginutils": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.2.0.tgz",
+      "integrity": "sha512-qWJ2ZTbmumwiLFomfzTyt5Kng4hwPi9rwCYN4SHb6eaRU1KNO4ccxINHr/VhH4GgPlt1XfSTLX2LBTme8ne4Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-yaml/node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/@rollup/plugin-yaml/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -9145,6 +9208,14 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/tosource": {
+      "version": "2.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/tosource/-/tosource-2.0.0-alpha.3.tgz",
+      "integrity": "sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/totalist": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@iconify-json/mdi": "^1.1.68",
     "@iconify-json/tabler": "^1.1.119",
     "@phosphor-icons/react": "^2.1.7",
+    "@rollup/plugin-yaml": "^4.1.2",
     "@types/react": "^19.0.10",
     "@types/react-dom": "^19.0.4",
     "astro": "^5.7.11",

--- a/src/components/SubCategoryCard.astro
+++ b/src/components/SubCategoryCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { LandingContentCard } from "../types/SubCategoryPageTypes";
 import IconSelection from "./IconSelection.tsx";
+import { resolveHref } from "~/utils/slugUtils.ts";
 
 import "@styles/main.css";
 
@@ -36,7 +37,14 @@ interface Props {
             </div>
             <div class=" flex flex-col">
                 {subitem.links.map((linkItem) => {
-                return <a class="text-superOfficeGreen" href={linkItem.url.slice(-3) == ".md" ? `${subCategory}/${linkItem.url.slice(0, -3)}` : linkItem.url}>{linkItem.text}</a>;
+                return (
+                  <a
+                    class="text-superOfficeGreen"
+                    href={resolveHref(linkItem.url, subCategory)}
+                  >
+                    {linkItem.text}
+                  </a>
+                );
               })}
               </div>
           );

--- a/src/components/TableOfContentList.tsx
+++ b/src/components/TableOfContentList.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import type { TocItem } from "~/types/TableOfContentTypes";
+import { trimFileExtension } from "~/utils/slugUtils";
+
 const base = import.meta.env.BASE_URL;
 
 type TableOfContentListProps = {
@@ -39,10 +41,12 @@ export default function TableOfContentList({
     if (isWebApiTOC) {
       return `${base}/en/api/reference/webapi/${item.uid}`;
     }
-
-    return item.topicHref
-      ? `${base}/${slug}/${item.topicHref?.replace(".md", "")}`
-      : `${base}/${slug}/${item.href?.replace(".md", "")}`;
+    const rawPath = item.topicHref || item.href;
+    if (!rawPath) {
+      console.warn(`[generatePath] Missing href/topicHref for TOC item:`, item);
+      return "#";
+    }
+    return `${base}/${slug}/${trimFileExtension(rawPath)}`;
   };
 
   const generateSlug = (item: TocItem) => {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -36,7 +36,27 @@ const DocsSchema = z.object({
 .passthrough().partial()
 // .partial() is used to make every property optional due to current frontmatter mismatch in some markdown files. Needs to be removed once frontmatter fixed
 
+const SimplifiedYamlSchema = z.object({
+  YamlMime: z.enum(["Category", "SubCategory"]), //- can't use as-is since it's a comment in our code
+  title: z.string(),
+  metadata: z.any(),
+}).passthrough(); // Allow all other fields like landingContent, conceptualContent, tools, etc.
 
+const TocItemSchema: z.ZodType<any> = z.lazy(() =>
+  z.object({
+    name: z.string(),
+    uid: z.string().optional(),
+    href: z.string().optional(),
+    topicHref: z.string().optional(),
+    items: z.array(TocItemSchema).optional(),
+  })
+);
+
+const TocYamlSchema = z.object({
+  items: z.array(TocItemSchema),
+});
+
+// Collections in src/content
 const releaseNotes = defineCollection({
   loader: glob({ pattern: ["*.md", "**/!(*includes*)/*.md"], base: "./src/content/release-notes" }),
   schema: DocsSchema,
@@ -57,6 +77,46 @@ const WebAPI = defineCollection({
   loader: glob({ pattern:["**/!(*toc).yml",], base:"./src/content/docs/en/api/reference/webapi"}),
 });
 
+const tocFilesInternal = defineCollection({
+  loader: glob({
+    pattern: ["**/toc.yml"],
+    base: "./src/content",
+  }),
+  schema: TocYamlSchema,
+});
+
+// Collections in external-content (cloned from another GitHub repo)
+
+const tocFilesExternal = defineCollection({
+  loader: glob({
+    pattern: ["contribution/**/toc.yml"], // Add in ext superoffice-docs later
+    base: "./external-content",
+  }),
+  schema: TocYamlSchema,
+});
+
+const externalLandingPages = defineCollection({
+  loader: glob({
+    pattern: [
+      "contribution/**/*.yml",
+      "!**/toc.yml",
+      // Add in ext superoffice-docs later
+    ],
+    base: "./external-content",
+  }),
+  schema: SimplifiedYamlSchema,
+});
+
+const contributionRepo = defineCollection({
+  loader: glob({
+    pattern: [
+      "**/*.md",
+      "!**/includes/**",
+      "!CODE_OF_CONDUCT.md"],
+    base: "./external-content/contribution",
+  }),
+  schema: DocsSchema,
+});
 
 // 3. Export a single `collections` object to register your collection(s)
 //    This key should match your collection directory name in "src/content"
@@ -65,6 +125,8 @@ export const collections = {
   en: enDocs,
   de: deDocs,
   webapi: WebAPI,
+  contribute: contributionRepo,
+  external: externalLandingPages,
+  tocInternal: tocFilesInternal,
+  tocExternal: tocFilesExternal,
 };
-
-

--- a/src/content/docs/en/api/reference/webapi/toc.yml
+++ b/src/content/docs/en/api/reference/webapi/toc.yml
@@ -1,4 +1,5 @@
 ### YamlMime:TableOfContent
+items:
 - uid: SuperOffice.License
   name: SuperOffice.License
   items:

--- a/src/layouts/SubCategoryLandingLayout.astro
+++ b/src/layouts/SubCategoryLandingLayout.astro
@@ -6,8 +6,11 @@ import TableOfContentList from "@components/TableOfContentList";
 import SubCategoryCard from "@components/SubCategoryCard.astro";
 import { Breadcrumbs } from "astro-breadcrumbs";
 import "astro-breadcrumbs/breadcrumbs.css";
-const { data, ToCData, lang } = Astro.props;
+const { data, ToCData, lang, baseSlug } = Astro.props;
 const currentPath = Astro.url.pathname;
+const parts = currentPath.split("/").filter(Boolean);
+const last = parts.at(-1);
+const subCategorySlug = last === "index" ? parts.at(-2) : last;
 
 const metadata = {
   title: data.title,
@@ -17,6 +20,7 @@ type Props = {
   data: SubCategoryContentItem;
   ToCData: TocData | null;
   lang: string;
+  baseSlug?: string;
 };
 ---
 
@@ -53,7 +57,7 @@ type Props = {
             <TableOfContentList
               client:only="react"
               inputItems={ToCData.items}
-              slug="en/"
+              slug={baseSlug ?? lang}
               isMainTable={true}
               isWebApiTOC={false}
             />
@@ -76,7 +80,7 @@ type Props = {
             data.landingContent.map((card) => {
               return (
                 <SubCategoryCard
-                  subCategory={currentPath.split("/").pop()}
+                  subCategory={subCategorySlug}
                   item={card}
                 />
               );

--- a/src/pages/contribute/[...slug].astro
+++ b/src/pages/contribute/[...slug].astro
@@ -1,0 +1,59 @@
+---
+import type { CollectionEntry } from "astro:content";
+import type { MarkdownHeading } from "astro";
+import { getCollection, render } from "astro:content";
+import { stripMarkdownSlug } from "~/utils/slugUtils";
+import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
+import MarkdownLayout from "@layouts/Markdown.astro";
+
+const collectionPath = "contribution";
+const allTocEntries = await getCollection("tocExternal");
+const tocEntries = allTocEntries.filter((entry) =>
+  entry.id.startsWith(collectionPath)
+);
+const tocData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
+
+export async function getStaticPaths() {
+  const docEntries = await getCollection("contribute");
+
+  const headings = await Promise.all(
+    docEntries.map(async (entry) => {
+      const rendered = await render(entry);
+      return rendered.headings;
+    })
+  );
+
+  const paths = docEntries.map((entry, index) => {
+    const slug = stripMarkdownSlug(entry.filePath!, "contribution", true);
+
+    return {
+      params: { slug },
+      props: { entry, headings: headings[index] }
+    };
+  });
+
+  return paths;
+}
+
+type Props = {
+  entry: CollectionEntry<"contribute">;
+  headings: MarkdownHeading[];
+};
+
+const { entry, headings } = Astro.props;
+
+const { Content } = await render(entry);
+---
+
+<MarkdownLayout
+  frontmatter={entry.data}
+  collection={entry.collection}
+  slug={entry.id}
+  filePath={entry.filePath}
+  headings={headings}
+  TableOfContentData={tocData}
+  isLearn={false}
+  lang="en"
+>
+  {Content ? <Content /> : "Loading..."}
+</MarkdownLayout>

--- a/src/pages/contribute/[subcategory].astro
+++ b/src/pages/contribute/[subcategory].astro
@@ -1,0 +1,70 @@
+---
+import { getCollection, getEntry } from "astro:content";
+import type { CollectionEntry } from "astro:content";
+import SubCategoryLandingLayout from "@layouts/SubCategoryLandingLayout.astro";
+import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
+import { trimFileExtension } from "~/utils/slugUtils";
+
+type SubCategoryDataType = Extract<
+  CollectionEntry<"external">["data"],
+  { YamlMime: "SubCategory" }
+>;
+
+// Build static paths from all SubCategory entries in external/contribution/
+export async function getStaticPaths() {
+  const collectionPath = "contribution";
+  const items = await getCollection("external");
+
+  const matched = items.filter(
+    (entry) =>
+      entry.data.YamlMime === "SubCategory" &&
+      entry.id.startsWith(`${collectionPath}`)
+  );
+
+  return matched.map((entry) => {
+    const rawSlug = entry.id === collectionPath
+      ? "" // when entry.id is exactly "contribution"
+      : entry.id.replace(`${collectionPath}/`, "");
+
+    const slug = rawSlug ? trimFileExtension(rawSlug) : "index";
+
+    return {
+      params: {
+        subcategory: slug,
+      },
+    };
+  });
+}
+
+const collectionPath = "contribution";
+
+// Get entry data
+const { subcategory } = Astro.params; // Will be 'index' or 'foo'
+
+const filePath = subcategory === "index"
+  ? `${collectionPath}`
+  : `${collectionPath}/${subcategory}`;
+
+const entry = await getEntry("external", filePath);
+if (!entry) {
+  throw new Error(`Subcategory not found or invalid: ${subcategory}`);
+}
+
+const SubCategoryData = entry.data as SubCategoryDataType;
+
+// Build toc
+const allTocEntries = await getCollection("tocExternal");
+
+const tocEntries = allTocEntries.filter((entry) =>
+  entry.id.startsWith(collectionPath) // Narrow to the relevant set for this folder
+);
+
+const ToCData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
+---
+
+<SubCategoryLandingLayout
+  lang="en"
+  baseSlug="contribute"
+  data={SubCategoryData}
+  ToCData={ToCData}
+/>

--- a/src/pages/release-notes/[...slug].astro
+++ b/src/pages/release-notes/[...slug].astro
@@ -3,13 +3,25 @@ import { getCollection, render } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import type { MarkdownHeading } from "astro";
 import MarkdownLayout from "@layouts/Markdown.astro";
+import { stripMarkdownSlug } from "~/utils/slugUtils";
 
-import { getTableOfContents } from "../../utils/getTableOfContents";
-const tocData = getTableOfContents("release-notes");
+// Old way of getting toc
+//import { getTableOfContents } from "../../utils/getTableOfContents";
+//const tocData = getTableOfContents("release-notes");
 
-//generating static paths from release-notes collection
+// New way of getting toc
+import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
+const collectionName = "release-notes";
+const allTocEntries = await getCollection("tocInternal");
+const tocEntries = allTocEntries.filter((entry) =>
+  entry.id.startsWith(collectionName)
+);
+const tocData = await getTableOfContentsFromCollection(tocEntries, collectionName);
+
+//Generate static paths from release-notes collection
 export async function getStaticPaths() {
-  const docEntries = await getCollection("release-notes");
+  const collectionName = "release-notes";
+  const docEntries = await getCollection(collectionName);
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {
@@ -20,8 +32,8 @@ export async function getStaticPaths() {
 
   return docEntries.map((entry, index) => {
 
-    //removing .md extention AND "src/content/release-notes" from filepath
-    const generatedSlug = entry.filePath?.replace("src/content/release-notes", "").replace(".md","");
+    //Remove .md extension AND "src/content/release-notes" from filepath
+    const generatedSlug = stripMarkdownSlug(entry.filePath!, collectionName, false);
 
     return {
       params: { slug: `${generatedSlug}` },

--- a/src/utils/getTableOfContentsFromCollection.ts
+++ b/src/utils/getTableOfContentsFromCollection.ts
@@ -1,0 +1,70 @@
+import type { CollectionEntry } from "astro:content";
+import type { TocData } from "~/types/TableOfContentTypes";
+import { trimFileExtension } from "~/utils/slugUtils";
+
+function isNestedTocFile(href: string): boolean {
+  const fileName = href.split("/").pop()?.toLowerCase();
+  return fileName === "toc.yml";
+}
+
+function normalizePath(path: string): string {
+  return trimFileExtension(path).replace(/\./g, "");
+}
+
+/**
+ * Recursively resolves a Table of Contents from a list of `toc.yml` entries,
+ * based on the root collection name (fex, "release-notes" or "docs/de").
+ *
+ * It builds a Map of all toc entries, finds the root toc file (fex, "release-notes/toc.yml"),
+ * and then walks through the nested structure, resolving any `href` fields
+ * that point to other `toc.yml` files in the collection.
+ *
+ * This enables a multi-file ToC to be constructed from modular parts, using content collections.
+ *
+ * @param tocEntries Filtered `tocInternal` or `tocExternal` entries matching a specific collection.
+ * @param rootCollectionName Path prefix to locate the root `toc.yml`, such as "release-notes".
+ * @returns A complete nested `TocData` object representing the full Table of Contents.
+ */
+
+export async function getTableOfContentsFromCollection(
+  tocEntries: CollectionEntry<"tocInternal" | "tocExternal">[],
+  rootCollectionName: string
+): Promise<TocData> {
+
+    
+  // Store all (filtered) tocEntries in a map so we can quickly look them up by their ID later
+  const tocMap = new Map<string, TocData>();
+  for (const entry of tocEntries) {
+    tocMap.set(entry.id, entry.data as TocData);
+  }
+
+  const rootId = trimFileExtension(`${rootCollectionName}/toc.yml`);
+  const root = tocMap.get(rootId);
+  if (!root) {
+    throw new Error(`No toc.yml found for collection: ${rootCollectionName}`);
+  }
+
+  const visited = new Set<string>();
+
+  // Recursively resolve nested toc.yml references
+  function resolveItems(items: any[]): any[] {
+    for (const item of items) {
+      const href = item.href;
+      if (href && isNestedTocFile(href)) {
+        const subId = normalizePath(`${rootCollectionName}/${href}`);
+        if (tocMap.has(subId) && !visited.has(subId)) {
+          visited.add(subId);
+          const subData = tocMap.get(subId);
+          if (subData?.items) {
+            item.items = resolveItems(subData.items);
+          }
+        }
+      }
+    }
+    return items;
+  }
+
+  visited.add(rootId);
+  root.items = resolveItems(root.items ?? []);
+  return root;
+}

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -1,0 +1,55 @@
+const supportedExtensions = [".md", ".mdx", ".yml", ".yaml"];
+
+/**
+ * Strips the slug prefix and file extension from an entry.filePath.
+ * For example: "src/content/release-notes/v11/index.md" -> "/v11/index"
+ */
+export function stripMarkdownSlug(filePath: string, collection: string, isExternal = false): string {
+  const base = isExternal
+  ? `external-content/${collection}/`
+  : `src/content/${collection}/`;
+
+  return filePath.replace(base, "").replace(/\.md$/, "");
+}
+
+/**
+ * Removes a known file extension (.md, .mdx, .yml, .yaml, .html) from a path.
+ * Logs a warning if an unknown or unsupported extension is detected.
+ */
+export function trimFileExtension(filename: string): string {
+  const knownExtPattern = /\.(mdx?|ya?ml|html)$/i;
+
+  if (!knownExtPattern.test(filename)) {
+    console.warn(`[trimFileExtension] Unknown or missing file extension in: "${filename}"`);
+    return filename;
+  }
+
+  return filename.replace(knownExtPattern, "");
+}
+
+/**
+ * Resolves a Markdown file link to a proper path.
+ *
+ * @param url - The original link from our data, for example 'learn/foo.md' or '../bar.md'.
+ * @param baseSlug - Optional prefix to prepend, such as 'document' or 'onsite'.
+ * @returns Resolved URL with no file extension and correct prefix.
+ */
+export function resolveHref(url: string, baseSlug?: string): string {
+  //console.warn(`[resolveHref] 🔹 url: "${url}", baseSlug: "${baseSlug}"`);
+  if (url.startsWith("http")) return url; // external, leave unchanged
+
+  const isSupported = supportedExtensions.some(ext => url.endsWith(ext));
+  if (!isSupported) return url;
+
+  const trimmed = trimFileExtension(url);
+
+  if (baseSlug === "contribute") { // special case for this repo
+    return trimmed;
+  }
+
+  if (baseSlug && url.startsWith(baseSlug + "/")) {
+    return trimmed;
+  }
+
+  return baseSlug ? `${baseSlug}/${trimmed}` : trimmed;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,5 +34,8 @@
     },
     "jsx": "react-jsx",
     "jsxImportSource": "react"
-  }
+  },
+   "exclude": [
+    "**/includes/*", "dist/"
+  ]
 }


### PR DESCRIPTION
## Usage

See readme.md

## File changes and why

* .gitignore: don't want to commit the "submodule" repos into this one
* astro.config.mjs and package.json: add Vite extension @rollup/plugin-yaml
* src/content.config.ts: define new collections (and their Zod schemas)
* src/components/SubCategoryCard.astro: improve readability by introducing utility function
* src/components/TableOfContentList.tsx: use utility function and add error handling
* src/content/docs/en/api/reference/webapi/toc.yml: add missing "item" (was breaking validation)
* src/layouts/SubCategoryLandingLayout.astro: add optional baseSlug prop; move subCategory logic to the component template and make it more robust
* src/pages/contribute/[...slug].astro: New route for contribute. Similar to pages/en/[...slug].astro, but uses the new utils/getTableOfContentsFromCollection.ts to generate tocData from a collection rather than loading with fs. syntax
* src/pages/contribute/[subcategory].astro: Handle subcategory page from contribution repo. Uses the new tocData logic + loads the contents of the subcategory page with await getEntry("external", filePath); instead of fs.syntax
* src/pages/release-notes/[...slug].astro: Uses the new tocData logic to demonstrate nested toc.yml behavior working, also within the existing src/content folder; refactor to use utility function.