### PR TITLE
CICD: update GitHub actions to import content from external repos

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,30 @@ jobs:
         with:
           repository: SuperOfficeDocs/contribution
           path: external-content/contribution
-      - name: Show contents
+      
+      # Following step is only required until contribution/index.yml gets updated with "YamlMime: SubCategory" as a property
+      - name: Update contribution/index.yml
         run: |
-          echo "Main Repo:"
-          ls -l
-          echo "Contribution Repo:"
-          ls -l external-content
+          set -e
+          FILE="external-content/contribution/index.yml"
+          LINE_TO_INSERT="YamlMime: SubCategory"
+
+          # Only insert if not already present at the top
+          if ! grep -Fxq "$LINE_TO_INSERT" "$FILE"; then
+            echo "Inserting line at top of $FILE"
+            tmpfile=$(mktemp)
+            echo "$LINE_TO_INSERT" > "$tmpfile"
+            echo "" >> "$tmpfile"
+            cat "$FILE" >> "$tmpfile"
+            mv "$tmpfile" "$FILE"
+          else
+            echo "Line already exists in $FILE"
+          fi
+      # Following step is only required until external-content\contribution\media\plain-action-buttons.PNG is capitalized correctly
+      - name: Fix capitalization issue in image files
+        run: |
+          mv "external-content/contribution/media/plain-action-buttons.PNG" "external-content/contribution/media/plain-action-buttons.png"
+          echo "Renamed image"
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         # with:


### PR DESCRIPTION
#### Changes
- Added a step to the build job to clone SuperOfficeDocs/contribution repo when building the site


#### Temporary changes
These changes should be removed once the repo is updated with fixes for these issues
- Added a temporary step to the build job to add "YamlMime: SubCategory" as a property to contribution/index.yml
- Added a temporary step to the build job to fix the capitalization issue in external-content/contribution/media/plain-action-buttons.PNG