### PR TITLE
feat: revamp webapi

### DIFF
--- a/src/components/WebApiClass.astro
+++ b/src/components/WebApiClass.astro
@@ -89,7 +89,7 @@ const selectedKeys = ["Constructor", "Method", "Property"];
       .filter(([typeName]) => selectedKeys.includes(typeName))
       .map(([typeName, items]) => (
         <div>
-          <h2 id={typeName} class="text-2xl">
+          <h2 id={conversionList[typeName as keyof typeof conversionList]} class="text-2xl">
             {conversionList[typeName as keyof typeof conversionList]}
             </h2>
           <div>

--- a/src/components/WebApiClass.astro
+++ b/src/components/WebApiClass.astro
@@ -3,7 +3,7 @@ import { Code } from 'astro:components';
 import type { ManagedReferenceType, Reference } from "../types/WebAPITypes";
 import type {indexDictionaryProps} from "../types/WebApiLayoutTypes"
 import WebAPIItem from "@components/WebApiItem.astro"
-
+import { conversionList } from '~/pages/en/api/reference/webapi/[...slug].astro';
 type Props = {
     data: ManagedReferenceType;
 };
@@ -19,14 +19,7 @@ const getDataFromReference = (uid:string) : Reference => {
   })[0]
 }
 
-const indexDictionary : indexDictionaryProps = {
-  Class: [],
-  Constructor: [],
-  Field: [],
-  Method : [],
-  Property : [],
-  Namespace: [],
-}
+const indexDictionary : indexDictionaryProps = {}
 
 data.items.forEach( (item , index) => {
   const key = item.type as keyof indexDictionaryProps;
@@ -35,6 +28,8 @@ data.items.forEach( (item , index) => {
   }
   indexDictionary[key].push(index);
 })
+
+const selectedKeys = ["Constructor", "Method", "Property"];
 
 
 ---
@@ -85,53 +80,62 @@ data.items.forEach( (item , index) => {
       </div>)}
     
     {/* Examples */}
-    {data.items[0].example && ( <div>
+    {data.items[0].example && data.items[0].example.length > 0 && ( <div>
         <h2 class="font-bold text-sm">Examples</h2>
         <p set:html = {data.items[0].example}></p>
       </div>)}
     
-
-    {indexDictionary.Constructor.length > 0 && ( 
-      <div>
-        <h2 id="Constructors" class="text-2xl">Constructors</h2>
+    {Object.entries(indexDictionary)
+      .filter(([typeName]) => selectedKeys.includes(typeName))
+      .map(([typeName, items]) => (
         <div>
-          {indexDictionary.Constructor.map( (indexNo) => {
-            return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
-          })}
+          <h2 id={typeName} class="text-2xl">
+            {conversionList[typeName as keyof typeof conversionList]}
+            </h2>
+          <div>
+            {items.map( (indexNo) => {
+              return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
+            })}
+          </div>
         </div>
-      </div>
-     )}
+    ))}
 
-    {indexDictionary.Field.length > 0 && (
+    {indexDictionary.Field?.length > 0 && (
       <div>
         <h2 id="Fields" class="text-2xl font-bold">Fields</h2>
-        {indexDictionary.Field.map( (indexNo) => {
-          return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
-        })}
+        
+        {data.items[0].type == "Enum" 
+        ? (
+          <table class="">
+            <tr class="[&>th]:font-bold [&>th]:border [&>th]:p-2 [&>th]:border-slate-400">
+              <th>Name</th>
+              <th>Description</th>
+            </tr>
+            {
+              indexDictionary.Field.map( (indexNo) => {
+              return (
+                <tr class="even:bg-neutral-100 [&>td]:pl-2  [&>td]:border [&>td]:border-slate-300">
+                  <td>{data.items[indexNo].name}</td>
+                  <td>{data.items[indexNo].summary}</td>
+                </tr>
+              )
+            })
+            }
+          </table>)
+        : indexDictionary.Field.map( (indexNo) => {
+            return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
+          })
+
+        }
       </div>
     )}
-    
-    {indexDictionary.Method.length > 0 && (
-      <div>
-        <h2 id="Methods" class="text-2xl font-bold">Methods</h2>
-        {indexDictionary.Method.map( (indexNo) => {
-          return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
-        })}
-      </div>)}
-
-    {indexDictionary.Property.length > 0 && ( 
-      <h2 id="Properties" class="text-2xl">Properties</h2>
-      <div>
-        {indexDictionary.Property.map( (indexNo) => {
-          return <WebAPIItem ref={data.references} item={data.items[indexNo]} />
-        })}
-      </div>
-     )}
+   
 
     
-    
+
+
     {
-      data.items[0].implements && data.items[0].implements.length > 0 &&
+      data.items[0].implements && data.items[0].implements?.length > 0 &&
       <div>
         <h2 id="Implements" class="text-2xl">Implements</h2>
         <div class="">

--- a/src/components/WebApiNamespace.astro
+++ b/src/components/WebApiNamespace.astro
@@ -1,46 +1,28 @@
 ---
 import type { namespaceClassifiedDataProps } from "../types/WebApiLayoutTypes";
 
-
 type Props = {
     namespaceData : namespaceClassifiedDataProps
 };
+
 const { namespaceData } = Astro.props;
 
 ---
 
 <div> 
-    {
-        namespaceData.Class.length > 0 && (
-            <div>
-                <h2 id="Classes" class="text-2xl mb-5">Classes</h2>
-                    {
-                    namespaceData.Class.map( (item)=> {
-                        return (
-                                <a class="font-bold text-orange-700 text-lg no-underline hover:underline" href={`${item.uid}`}>{item.id}</a>
-                                <p class="ml-4 !prose" set:html = {item.summary}></p>
-                        )
-                })}
-                 
-            </div>
-        )
-    }
-    {   
-        namespaceData.Interface.length > 0 && (
-            <div>
-                <h2 id="Interfaces" class="text-2xl mb-5">Interfaces</h2>
-                    {
-                    namespaceData.Interface.map( (item)=> {
-                        return (
+    {Object.entries(namespaceData).map(([typeName, items]) => (
+        <div>
+            <h2 id="Classes" class="text-2xl mb-5">{typeName}</h2>
+            {
+                items.map( (item)=> {
+                    return (
                             <a class="font-bold text-orange-700 text-lg no-underline hover:underline" href={`${item.uid}`}>{item.id}</a>
-                            <p class="ml-4 !prose" set:html = {item.summary}></p>   
-                        )
-                })}
-                 
-            </div>
-        )
-}
-
+                            <p class="ml-4 !prose" set:html = {item.summary}></p>
+                    )
+            })}
+        </div>
+    ))
+    }
 </div>
 
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -77,14 +77,6 @@ const WebAPI = defineCollection({
   loader: glob({ pattern:["**/!(*toc).yml",], base:"./src/content/docs/en/api/reference/webapi"}),
 });
 
-const tocFilesInternal = defineCollection({
-  loader: glob({
-    pattern: ["**/toc.yml"],
-    base: "./src/content",
-  }),
-  schema: TocYamlSchema,
-});
-
 // Collections in external-content (cloned from another GitHub repo)
 
 const tocFilesExternal = defineCollection({
@@ -93,7 +85,7 @@ const tocFilesExternal = defineCollection({
       "superoffice-docs/docs/**/toc.yml",
       "superoffice-docs/release-notes/**/toc.yml",
       "contribution/**/toc.yml",
-    ], // Add in ext superoffice-docs later
+    ],
     base: "./external-content",
   }),
   schema: TocYamlSchema,
@@ -131,6 +123,5 @@ export const collections = {
   webapi: WebAPI,
   contribute: contributionRepo,
   external: externalLandingPages,
-  tocInternal: tocFilesInternal,
   tocExternal: tocFilesExternal,
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -89,7 +89,11 @@ const tocFilesInternal = defineCollection({
 
 const tocFilesExternal = defineCollection({
   loader: glob({
-    pattern: ["contribution/**/toc.yml"], // Add in ext superoffice-docs later
+    pattern: [
+      "superoffice-docs/docs/**/toc.yml",
+      "superoffice-docs/release-notes/**/toc.yml",
+      "contribution/**/toc.yml",
+    ], // Add in ext superoffice-docs later
     base: "./external-content",
   }),
   schema: TocYamlSchema,

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -3,37 +3,37 @@ import { z, defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 
 const DocsSchema = z.object({
-  
+
   //Mandatory Properties
-  author : z.union([
-    z.string(), 
-    z.object({ "github-id" : z.string().nullable()}),
+  author: z.union([
+    z.string(),
+    z.object({ "github-id": z.string().nullable() }),
   ]).nullable(),
-  date : z.coerce.string().nullable(),
-  title : z.string().nullable(),
-  uid : z.string().nullable(),
-  topic : z.string().nullable(),
-  
+  date: z.coerce.string().nullable(),
+  title: z.string().nullable(),
+  uid: z.string().nullable(),
+  topic: z.string().nullable(),
+
 
   //Optional Properties
-  description : z.string().optional().nullable(),
-  audience : z.string().optional().nullable(),
-  audience_tooltip : z.string().optional().nullable(),
-  category : z.string().optional().nullable(),
-  updated : z.date().optional().nullable(),
-  version : z.coerce.string().optional().nullable(),
-  version_sofo : z.coerce.string().optional().nullable(),
-  version_devportal : z.coerce.string().optional().nullable(),
-  version_mobile : z.coerce.string().optional().nullable(),
-  translation_type : z.number().optional().nullable(),
-  envir : z.union([z.string(), z.array(z.string())]).optional().nullable(),
-  generated : z.boolean().optional().nullable(),
-  keywords : z.union([z.string(), z.array(z.string())]).optional().nullable(),
-  language : z.string().max(2).optional().nullable(),
-  pilot : z.string().optional().nullable(),
-  redirect_url : z.string().optional().nullable(),
+  description: z.string().optional().nullable(),
+  audience: z.string().optional().nullable(),
+  audience_tooltip: z.string().optional().nullable(),
+  category: z.string().optional().nullable(),
+  updated: z.date().optional().nullable(),
+  version: z.coerce.string().optional().nullable(),
+  version_sofo: z.coerce.string().optional().nullable(),
+  version_devportal: z.coerce.string().optional().nullable(),
+  version_mobile: z.coerce.string().optional().nullable(),
+  translation_type: z.number().optional().nullable(),
+  envir: z.union([z.string(), z.array(z.string())]).optional().nullable(),
+  generated: z.boolean().optional().nullable(),
+  keywords: z.union([z.string(), z.array(z.string())]).optional().nullable(),
+  language: z.string().max(2).optional().nullable(),
+  pilot: z.string().optional().nullable(),
+  redirect_url: z.string().optional().nullable(),
 })
-.passthrough().partial()
+  .passthrough().partial()
 // .partial() is used to make every property optional due to current frontmatter mismatch in some markdown files. Needs to be removed once frontmatter fixed
 
 const SimplifiedYamlSchema = z.object({
@@ -63,7 +63,7 @@ const releaseNotes = defineCollection({
 });
 
 const enDocs = defineCollection({
-  loader: glob({ pattern: "**/!(**includes**)/*.md",  base: "./src/content/docs/en" }),
+  loader: glob({ pattern: "**/!(**includes**)/*.md", base: "./src/content/docs/en" }),
   schema: DocsSchema,
 });
 
@@ -74,7 +74,7 @@ const deDocs = defineCollection({
 
 
 const WebAPI = defineCollection({
-  loader: glob({ pattern:["**/!(*toc).yml",], base:"./src/content/docs/en/api/reference/webapi"}),
+  loader: glob({ pattern: ["**/!(*toc).yml",], base: "external-content/superoffice-docs/docs/en/api/reference/webapi" }),
 });
 
 // Collections in external-content (cloned from another GitHub repo)

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -41,7 +41,7 @@ if (collection != "release-notes") {
       >
         <TableOfContentList
           client:only="react"
-          inputItems={isWebAPI ? TableOfContentData : TableOfContentData?.items}
+          inputItems={TableOfContentData?.items}
           slug={TOCPath}
           isMainTable={true}
           isWebApiTOC={isWebAPI}

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -13,11 +13,10 @@ export async function getStaticPaths() {
       return data.headings;
     })
   );
-
   return docEntries.map((entry, index) => {
     //removing .md extention AND "src/content/en" from filepath
     const generatedSlug = entry.filePath
-      ?.replace("src/content/docs/en", "")
+      ?.replace("external-content/superoffice-docs/docs/en", "")
       .replace(".md", "");
     const category = generatedSlug?.split("/")[1];
     const isLearn = entry.data.uid?.startsWith("help");

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -16,7 +16,7 @@ export async function getStaticPaths() {
   return docEntries.map((entry, index) => {
     //removing .md extention AND "src/content/en" from filepath
     const generatedSlug = entry.filePath
-      ?.replace("external-content/superoffice-docs/docs/en", "")
+      ?.replace("src/content/docs/en", "")
       .replace(".md", "");
     const category = generatedSlug?.split("/")[1];
     const isLearn = entry.data.uid?.startsWith("help");

--- a/src/pages/en/api/reference/webapi/[...slug].astro
+++ b/src/pages/en/api/reference/webapi/[...slug].astro
@@ -10,6 +10,18 @@ import type {
 } from "../../../../../types/WebApiLayoutTypes";
 import { getEntry } from "astro:content";
 import type { Item } from "../../../../../types/WebAPITypes";
+import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
+
+const language = "en";
+const collectionPath = `superoffice-docs/docs/${language}/api/reference/webapi`;
+const allTocEntries = await getCollection("tocExternal");
+const tocEntries = allTocEntries.filter((entry) =>
+  entry.id.startsWith(collectionPath)
+);
+const tocData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
+
+
+
 
 // Generates static paths from webapi collection
 export async function getStaticPaths() {
@@ -21,15 +33,14 @@ export async function getStaticPaths() {
         "",
       )
       .replace(".yml", "");
-    const tocData = getTableOfContents(`docs/en/api/reference/webapi`);
     return {
       params: { slug: `${generatedSlug}` },
-      props: { entry, tocData },
+      props: { entry },
     };
   });
 }
 
-const { entry, tocData } = Astro.props;
+const { entry} = Astro.props;
 const pagetitle = entry.data.items[0].type + " " + entry.data.items[0].id;
 
 // Use to get the plural forms of the name
@@ -49,7 +60,6 @@ const headingList: headingsListProps = {};
 const namespaceData: namespaceClassifiedDataProps = {};
 
 const documentType = entry.data.items[0].type;
-
 if (documentType == "Namespace") {
   const promises = entry.data.items[0].children?.map(
     async (childName: string) => {

--- a/src/pages/en/api/reference/webapi/[...slug].astro
+++ b/src/pages/en/api/reference/webapi/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection, render } from "astro:content";
+import { getCollection } from "astro:content";
 import MarkdownLayout from "@layouts/Markdown.astro";
 import { getTableOfContents } from "@utils/getTableOfContents";
 import WebApiNamespace from "@components/WebApiNamespace.astro";
@@ -11,13 +11,15 @@ import type {
 import { getEntry } from "astro:content";
 import type { Item } from "../../../../../types/WebAPITypes";
 
-//generating static paths from webapi collection
+// Generates static paths from webapi collection
 export async function getStaticPaths() {
   const YMLEntries = await getCollection("webapi");
-
   return YMLEntries.map((entry) => {
     const generatedSlug = entry.filePath
-      ?.replace("src/content/docs/en/api/reference/webapi", "")
+      ?.replace(
+        "external-content/superoffice-docs/docs/en/api/reference/webapi",
+        "",
+      )
       .replace(".yml", "");
     const tocData = getTableOfContents(`docs/en/api/reference/webapi`);
     return {
@@ -30,19 +32,8 @@ export async function getStaticPaths() {
 const { entry, tocData } = Astro.props;
 const pagetitle = entry.data.items[0].type + " " + entry.data.items[0].id;
 
-//Genereting heading from yml data
-const headings = [{ depth: 0, slug: "", text: "" }];
-const headingList: headingsListProps = {
-  Class: [],
-  Constructor: [],
-  Field: [],
-  Method: [],
-  Property: [],
-  Interface: [],
-  Implement: [],
-};
-
-const conversionList = {
+// Use to get the plural forms of the name
+export const conversionList = {
   Class: "Classes",
   Constructor: "Constructors",
   Field: "Fields",
@@ -50,19 +41,22 @@ const conversionList = {
   Property: "Properties",
   Interface: "Interfaces",
   Implement: "Implements",
+  Enum: "Enums",
 };
 
-const namespaceData: namespaceClassifiedDataProps = {
-  Class: [],
-  Interface: [],
-};
+// Genereting heading from yml data
+const headingList: headingsListProps = {};
+const namespaceData: namespaceClassifiedDataProps = {};
 
-if (entry.data.items[0].type == "Namespace") {
+const documentType = entry.data.items[0].type;
+
+if (documentType == "Namespace") {
   const promises = entry.data.items[0].children?.map(
     async (childName: string) => {
       const formattedItem = childName.replaceAll(".", "").toLowerCase();
       const childrenItemEntry = await getEntry("webapi", formattedItem);
       if (childrenItemEntry) {
+        console.log(childrenItemEntry.id);
         const dataItem = childrenItemEntry?.data.items[0];
         const key = dataItem.type as keyof namespaceClassifiedDataProps;
         if (!namespaceData[key]) {
@@ -73,68 +67,68 @@ if (entry.data.items[0].type == "Namespace") {
           id: dataItem.id,
           summary: dataItem.summary,
         });
-
-        headingList[key].push({
-          text: dataItem.id,
-          slug: dataItem.uid,
-        });
+        appendIntoHeadingList(key, dataItem);
       }
-    }
+    },
   );
 
   await Promise.all(promises || []);
-
-  let ItemType: keyof headingsListProps;
-  for (ItemType in headingList) {
-    if (headingList[ItemType].length > 0) {
-      headings.push({
-        depth: 2,
-        slug: conversionList[ItemType],
-        text: conversionList[ItemType],
-      });
-    }
-  }
-}
-
-if (
-  entry.data.items[0].type == "Class" ||
-  entry.data.items[0].type == "Interface"
-) {
-  const itemsExceptClassItem = entry.data.items.slice(1);
-  itemsExceptClassItem.forEach((item: Item) => {
-    const key = item.type as keyof headingsListProps;
-    headingList[key].push({
-      text: item.name,
-      slug: item.uid,
-    });
+} else if (["Class", "Interface", "Enum"].includes(documentType)) {
+  // Append headings of every other item except parent item to headingsList
+  const otherItemsExceptParentItem = entry.data.items.slice(1);
+  otherItemsExceptParentItem.forEach((dataItem: Item) => {
+    const key = dataItem.type as keyof headingsListProps;
+    appendIntoHeadingList(key, dataItem);
   });
 
+  // Check if implements exist and add them to headingList
   if (
     entry.data.items[0].implements &&
     entry.data.items[0].implements.length > 0
   ) {
     const key = "Implement" as keyof headingsListProps;
     entry.data.items[0].implements.forEach((item: string) => {
+      if (!(key in headingList)) {
+        headingList[key] = [];
+      }
       headingList[key].push({
         text: item,
         slug: item,
       });
     });
   }
+}
 
-  let ItemType: keyof headingsListProps;
-  for (ItemType in headingList) {
-    if (headingList[ItemType].length > 0) {
-      headings.push({
-        depth: 2,
-        slug: conversionList[ItemType],
-        text: conversionList[ItemType],
-      });
-      headingList[ItemType].map((item) => {
-        headings.push({ depth: 3, slug: `${item.slug}`, text: item.text });
-      });
-    }
+// Generate heading based on collected headings in headingList
+const headings = [{ depth: 0, slug: "", text: "" }];
+let ItemType: keyof headingsListProps;
+for (ItemType in headingList) {
+  if (headingList[ItemType].length > 0) {
+    headings.push({
+      depth: 2,
+      slug: conversionList[ItemType as keyof typeof conversionList],
+      text: conversionList[ItemType as keyof typeof conversionList],
+    });
+    headingList[ItemType].map((item) => {
+      headings.push({ depth: 3, slug: `${item.slug}`, text: item.text });
+    });
   }
+}
+
+/**
+ * Appends headings into headingList according to relevent key
+ *
+ * @param key - key of the heading to be included (ex: Class, Constructor, Enum)
+ * @param dataItem - dataItem's extracted from the yml
+ */
+function appendIntoHeadingList(key: keyof headingsListProps, dataItem: Item) {
+  if (!(key in headingList)) {
+    headingList[key] = [];
+  }
+  headingList[key].push({
+    text: dataItem.id,
+    slug: dataItem.uid,
+  });
 }
 ---
 
@@ -152,14 +146,13 @@ if (
     <h1 class="text-3xl md:text-4xl break-words mt-6 mb-6">{pagetitle}</h1>
 
     {
-      entry.data.items[0].type == "Namespace" && (
+      documentType == "Namespace" && (
         <WebApiNamespace namespaceData={namespaceData} />
       )
     }
 
     {
-      (entry.data.items[0].type == "Class" ||
-        entry.data.items[0].type == "Interface") && (
+      ["Class", "Interface", "Enum"].includes(documentType) && (
         <WebApiClass data={entry.data} />
       )
     }

--- a/src/pages/en/api/reference/webapi/[...slug].astro
+++ b/src/pages/en/api/reference/webapi/[...slug].astro
@@ -1,15 +1,14 @@
 ---
 import { getCollection } from "astro:content";
 import MarkdownLayout from "@layouts/Markdown.astro";
-import { getTableOfContents } from "@utils/getTableOfContents";
 import WebApiNamespace from "@components/WebApiNamespace.astro";
 import WebApiClass from "@components/WebApiClass.astro";
 import type {
   headingsListProps,
   namespaceClassifiedDataProps,
-} from "../../../../../types/WebApiLayoutTypes";
+} from "~/types/WebApiLayoutTypes";
 import { getEntry } from "astro:content";
-import type { Item } from "../../../../../types/WebAPITypes";
+import type { Item } from "~/types/WebAPITypes";
 import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
 
 const language = "en";

--- a/src/pages/en/api/reference/webapi/[...slug].astro
+++ b/src/pages/en/api/reference/webapi/[...slug].astro
@@ -16,12 +16,12 @@ const language = "en";
 const collectionPath = `superoffice-docs/docs/${language}/api/reference/webapi`;
 const allTocEntries = await getCollection("tocExternal");
 const tocEntries = allTocEntries.filter((entry) =>
-  entry.id.startsWith(collectionPath)
+  entry.id.startsWith(collectionPath),
 );
-const tocData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
-
-
-
+const tocData = await getTableOfContentsFromCollection(
+  tocEntries,
+  collectionPath,
+);
 
 // Generates static paths from webapi collection
 export async function getStaticPaths() {
@@ -40,7 +40,7 @@ export async function getStaticPaths() {
   });
 }
 
-const { entry} = Astro.props;
+const { entry } = Astro.props;
 const pagetitle = entry.data.items[0].type + " " + entry.data.items[0].id;
 
 // Use to get the plural forms of the name

--- a/src/pages/release-notes/[...slug].astro
+++ b/src/pages/release-notes/[...slug].astro
@@ -12,7 +12,7 @@ import { stripMarkdownSlug } from "~/utils/slugUtils";
 // New way of getting toc
 import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
 const collectionName = "release-notes";
-const allTocEntries = await getCollection("tocInternal");
+const allTocEntries = await getCollection("tocExternal");
 const tocEntries = allTocEntries.filter((entry) =>
   entry.id.startsWith(collectionName)
 );

--- a/src/pages/release-notes/[...slug].astro
+++ b/src/pages/release-notes/[...slug].astro
@@ -11,7 +11,7 @@ import { stripMarkdownSlug } from "~/utils/slugUtils";
 
 // New way of getting toc
 import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
-const collectionName = "release-notes";
+const collectionName = "superoffice-docs/release-notes";
 const allTocEntries = await getCollection("tocExternal");
 const tocEntries = allTocEntries.filter((entry) =>
   entry.id.startsWith(collectionName)

--- a/src/types/WebApiLayoutTypes.ts
+++ b/src/types/WebApiLayoutTypes.ts
@@ -1,23 +1,9 @@
-import type { Item } from "../types/WebAPITypes";
-
-
 export interface indexDictionaryProps {
-    Class: number[];
-    Constructor: number[];
-    Method : number[];
-    Property: number[];
-    Field: number[];
-    Namespace: number[];
+    [key: string]: number[]; 
 }
 
 export interface headingsListProps {
-    Class: headingsItem[];
-    Constructor: headingsItem[];
-    Method : headingsItem[];
-    Property: headingsItem[];
-    Field: headingsItem[];
-    Interface : headingsItem[];
-    Implement : headingsItem[];
+  [key: string]: headingsItem[]; 
 }
 
 interface headingsItem {
@@ -26,8 +12,7 @@ interface headingsItem {
 }
 
 export interface namespaceClassifiedDataProps {
-    Class: namespaceClassifiedDataItem [];
-    Interface: namespaceClassifiedDataItem [];
+    [key: string]: namespaceClassifiedDataItem [];
 }
 
 interface namespaceClassifiedDataItem {

--- a/src/utils/getTableOfContentsFromCollection.ts
+++ b/src/utils/getTableOfContentsFromCollection.ts
@@ -27,7 +27,7 @@ function normalizePath(path: string): string {
  */
 
 export async function getTableOfContentsFromCollection(
-  tocEntries: CollectionEntry<"tocInternal" | "tocExternal">[],
+  tocEntries: CollectionEntry<"tocExternal">[],
   rootCollectionName: string
 ): Promise<TocData> {
 


### PR DESCRIPTION
- Simplified and abstracted the keys of the headings to allow for future extensions
- Updated webspi/[..slug] component to get content from external content collections
- Updated TableOfContent in webApi to get content from external content collections
- Simplified types in WebApiLayoutTypes
- Updated en and release notes collection paths

Changes introduced in this PR build upon changes in PR #157 