### PR TITLE
cicd: removed temporary fixes added to github actions deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,30 +38,6 @@ jobs:
         with:
           repository: SuperOfficeDocs/contribution
           path: external-content/contribution
-      
-      # Following step is only required until contribution/index.yml gets updated with "YamlMime: SubCategory" as a property
-      - name: Update contribution/index.yml
-        run: |
-          set -e
-          FILE="external-content/contribution/index.yml"
-          LINE_TO_INSERT="YamlMime: SubCategory"
-
-          # Only insert if not already present at the top
-          if ! grep -Fxq "$LINE_TO_INSERT" "$FILE"; then
-            echo "Inserting line at top of $FILE"
-            tmpfile=$(mktemp)
-            echo "$LINE_TO_INSERT" > "$tmpfile"
-            echo "" >> "$tmpfile"
-            cat "$FILE" >> "$tmpfile"
-            mv "$tmpfile" "$FILE"
-          else
-            echo "Line already exists in $FILE"
-          fi
-      # Following step is only required until external-content\contribution\media\plain-action-buttons.PNG is capitalized correctly
-      - name: Fix capitalization issue in image files
-        run: |
-          mv "external-content/contribution/media/plain-action-buttons.PNG" "external-content/contribution/media/plain-action-buttons.png"
-          echo "Renamed image"
       - name: Install, build, and upload your site
         uses: withastro/action@v3
         # with:

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -37,7 +37,7 @@ const DocsSchema = z.object({
 // .partial() is used to make every property optional due to current frontmatter mismatch in some markdown files. Needs to be removed once frontmatter fixed
 
 const SimplifiedYamlSchema = z.object({
-  YamlMime: z.enum(["Category", "SubCategory"]), //- can't use as-is since it's a comment in our code
+  yamlMime: z.enum(["Category", "SubCategory"]), //- can't use as-is since it's a comment in our code
   title: z.string(),
   metadata: z.any(),
 }).passthrough(); // Allow all other fields like landingContent, conceptualContent, tools, etc.


### PR DESCRIPTION
Removed the following temporary fixes added to the workflow.yaml
- contribution/index.yml gets updated with "YamlMime: SubCategory" as a property
- changed file path casing in external-content\contribution\media\plain-action-buttons.PNG

Renamed yamlMime property in schema of content.config.ts