### PR TITLE
cicd: added condition to skip deploy job from forked repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -165,16 +165,13 @@ jobs:
             echo "skip_deploy=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Exit early if deployment is skipped
-        if: steps.check_pr_source.outputs.skip_deploy == 'true'
-        run: exit 0
-
-
       - name: Upload GitHub Pages artifact
+        if: steps.check_pr_source.outputs.skip_deploy == 'false'
         uses: actions/upload-pages-artifact@v3
         with:
           path: final-dist
 
       - name: Deploy to GitHub Pages
+        if: steps.check_pr_source.outputs.skip_deploy == 'false'
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,6 +154,23 @@ jobs:
 
       - name: Index pages using Pagefind
         run: npx pagefind --site final-dist
+      
+      - name: Check if the PR originates from source repo
+        id: check_pr_source
+        run: |
+          echo "PR source: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Base repo: ${{ github.repository }}"
+          if [ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ] && [ "${{ github.event_name }}" == "pull_request" ]; then
+            echo "PR is from a forked repo. Skipping deployment."
+            echo "skip_deploy=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_deploy=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Exit early if deployment is skipped
+        if: steps.check_pr_source.outputs.skip_deploy == 'true'
+        run: exit 0
+
 
       - name: Upload GitHub Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,8 +118,6 @@ jobs:
 
   # deploy job downloads artifacts from build jobs, merge them in to one directory, create search index, and deploy to github pages
   deploy:
-    # run the deploy job if it only comes from main repo (not from a forked repo)
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     needs: [build-main, build-api]
     runs-on: ubuntu-latest
     environment:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,8 @@ jobs:
 
   # deploy job downloads artifacts from build jobs, merge them in to one directory, create search index, and deploy to github pages
   deploy:
+    # run the deploy job if it only comes from main repo (not from a forked repo)
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push'
     needs: [build-main, build-api]
     runs-on: ubuntu-latest
     environment:


### PR DESCRIPTION
- Updated workflow.yml to skip the deploy job if the PR is not originating from the source repo (skips PR's originating from forked repo's) 