### PR TITLE
feat: defined a seperate content collection for api/reference

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -23,25 +23,26 @@ const enDocs = defineCollection({
       "**/*.md",               // Include all .md files recursively
       "!*.md",                 // Exclude .md files in the root (docs/en/*.md)
       "!**/includes/**",       // Exclude any path that includes a folder named "includes"
-      "!api/**/*.md",               // Exclude api folder
+      "!api/reference/**/*.md",               // Exclude api folder
+      "!api/tutorials/minimal-csharp-app", //Temporary excluded until corrupted images problem is resolved
     ],
     base: "external-content/superoffice-docs/docs/en",
   }),
   schema: DocsSchema,
 });
 
-const apiDocs = defineCollection({
+const referenceDocs = defineCollection({
   loader: glob({
     pattern: apiOnly ? [
       "**/*.md",               // Include all .md files recursively
       "!**/includes/**",       // Exclude any path that includes a folder named "includes"
       
-      "!tutorials/minimal-csharp-app", //Temporary excluded until corrupted images problem is resolved
-      "!reference/soap",   // Exclude .md files in the root (external-content/*.md)
-      "!reference/restful",   // Exclude files 
-      "!reference/netserver",   // Exclude files
+      
+      "!soap",   // Exclude .md files in the root (external-content/*.md)
+      "!restful",   // Exclude files 
+      "!netserver",   // Exclude files
     ] : [""],
-    base: "external-content/superoffice-docs/docs/en/api",
+    base: "external-content/superoffice-docs/docs/en/api/reference",
   }),
   schema: DocsSchema,
 })
@@ -105,7 +106,7 @@ export const collections = {
   "release-notes": releaseNotes,
   en: enDocs,
   de: deDocs,
-  "api-docs" : apiDocs,
+  "reference-docs" : referenceDocs,
   webapi: WebAPI,
   contribute: contribution,
   external: externalLandingPages,

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -23,13 +23,28 @@ const enDocs = defineCollection({
       "**/*.md",               // Include all .md files recursively
       "!*.md",                 // Exclude .md files in the root (docs/en/*.md)
       "!**/includes/**",       // Exclude any path that includes a folder named "includes"
-      "!api/tutorials/minimal-csharp-app", //Temporary excluded until corrupted images problem is resolved
-      "!api/reference/soap"   // Exclude .md files in the root (external-content/*.md)
+      "!api/**/*.md",               // Exclude api folder
     ],
     base: "external-content/superoffice-docs/docs/en",
   }),
   schema: DocsSchema,
 });
+
+const apiDocs = defineCollection({
+  loader: glob({
+    pattern: apiOnly ? [
+      "**/*.md",               // Include all .md files recursively
+      "!**/includes/**",       // Exclude any path that includes a folder named "includes"
+      
+      "!tutorials/minimal-csharp-app", //Temporary excluded until corrupted images problem is resolved
+      "!reference/soap",   // Exclude .md files in the root (external-content/*.md)
+      "!reference/restful",   // Exclude files 
+      "!reference/netserver",   // Exclude files
+    ] : [""],
+    base: "external-content/superoffice-docs/docs/en/api",
+  }),
+  schema: DocsSchema,
+})
 
 const deDocs = defineCollection({
   loader: glob({ pattern: apiOnly ? [""] : [
@@ -48,7 +63,10 @@ const WebAPI = defineCollection({
 
 const tocFiles = defineCollection({
   loader: glob({
-    pattern: apiOnly ? ["superoffice-docs/docs/en/api/**/toc.yml"] : [
+    pattern: apiOnly ? [
+      "superoffice-docs/docs/en/api/**/toc.yml",
+      "superoffice-docs/docs/en/api/toc.yml",
+    ] : [
       "superoffice-docs/docs/en/!(api)/**/toc.yml",
       "superoffice-docs/docs/**/toc.yml",
       "superoffice-docs/release-notes/**/toc.yml",
@@ -87,6 +105,7 @@ export const collections = {
   "release-notes": releaseNotes,
   en: enDocs,
   de: deDocs,
+  "api-docs" : apiDocs,
   webapi: WebAPI,
   contribute: contribution,
   external: externalLandingPages,

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -12,14 +12,17 @@ const {
   headings,
   TableOfContentData,
   isLearn,
-  isWebAPI = false,
   lang,
 } = Astro.props;
-var TOCPath = collection;
 
 // Appends specific category of the page for langauge content collections (For every collection except for release-notes collection)
-if (collection != "release-notes") {
-  TOCPath = TOCPath.concat(`/${isLearn ? "learn" : slug.split("/")[0]}`);
+var TOCPath;
+if (collection == "release-notes") {
+  TOCPath = collection;
+} else if (collection == "api-docs") {
+  TOCPath = lang.concat("/api");
+} else {
+  TOCPath = lang.concat(`/${isLearn ? "learn" : slug.split("/")[0]}`);
 }
 ---
 
@@ -44,7 +47,6 @@ if (collection != "release-notes") {
           inputItems={TableOfContentData?.items}
           slug={TOCPath}
           isMainTable={true}
-          isWebApiTOC={isWebAPI}
           transition:persist
         />
       </nav>

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -18,9 +18,7 @@ const {
 // Appends specific category of the page for langauge content collections (For every collection except for release-notes collection)
 var TOCPath;
 if (collection == "release-notes") {
-  TOCPath = collection;
-} else if (collection == "api-docs") {
-  TOCPath = "en/api";
+  TOCPath = "release-notes";
 } else {
   TOCPath = lang.concat(`/${isLearn ? "learn" : slug.split("/")[0]}`);
 }

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -20,7 +20,7 @@ var TOCPath;
 if (collection == "release-notes") {
   TOCPath = collection;
 } else if (collection == "api-docs") {
-  TOCPath = lang.concat("/api");
+  TOCPath = "en/api";
 } else {
   TOCPath = lang.concat(`/${isLearn ? "learn" : slug.split("/")[0]}`);
 }

--- a/src/layouts/SubCategoryLandingLayout.astro
+++ b/src/layouts/SubCategoryLandingLayout.astro
@@ -59,7 +59,6 @@ type Props = {
               inputItems={ToCData.items}
               slug={baseSlug ?? lang}
               isMainTable={true}
-              isWebApiTOC={false}
             />
           )
         }

--- a/src/pages/en/api/[...slug].astro
+++ b/src/pages/en/api/[...slug].astro
@@ -1,12 +1,12 @@
 ---
 import { getCollection, render } from "astro:content";
 import MarkdownLayout from "@layouts/Markdown.astro";
-import { getTableOfContents } from "../../utils/getTableOfContents";
+import { getTableOfContents } from "~/utils/getTableOfContents";
 import { stripFilePathAndExtension } from "~/utils/slugUtils";
 
 //generating static paths from en collection
 export async function getStaticPaths() {
-  const docEntries = await getCollection("en");
+  const docEntries = await getCollection("api-docs");
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {
@@ -15,44 +15,43 @@ export async function getStaticPaths() {
     }),
   );
   return docEntries.map((entry, index) => {
-    //Remove .md extension AND filepath prefix (ex:superoffice-docs/docs/en) from filepath
+    //Remove .md extension AND filepath prefix (ex:superoffice-docs/docs/en/api) from filepath
     const generatedSlug = stripFilePathAndExtension(
       entry.filePath!,
-      `superoffice-docs/docs/en`,
+      `superoffice-docs/docs/en/api`,
       true,
     );
     
     const category = generatedSlug?.split("/")[0];
-    const isLearn = entry.data.uid?.startsWith("help");
 
     function getTocPath(): string{
-      if (isLearn) return "learn";
-      return category;
+      if (category == "reference") return `/${generatedSlug.substring(0, generatedSlug.lastIndexOf("/"))}`;
+      return ""
     }
 
     const tocPath = getTocPath();
-    const tocData = getTableOfContents(`docs/en/${tocPath}`);
+    const tocData = getTableOfContents(`docs/en/api${tocPath}`);
 
     return {
       params: { slug: `${generatedSlug}` },
-      props: { entry, headings: headings[index], tocData, isLearn },
+      props: { entry, headings: headings[index], tocData },
     };
   });
 }
 
-const { entry, headings, tocData, isLearn } = Astro.props;
-
+const { entry, headings, tocData } = Astro.props;
 const { Content } = await render(entry);
+
 ---
 
 <MarkdownLayout
   frontmatter={entry.data}
-  collection={entry.collection}
+  collection={"api-docs"}
   slug={entry.id}
   filePath={entry.filePath}
   headings={headings}
   TableOfContentData={tocData}
-  isLearn={isLearn}
+  isLearn={false}
   lang="en"
 >
   {Content ? <Content /> : "Loading content..."}

--- a/src/pages/en/api/reference/[...slug].astro
+++ b/src/pages/en/api/reference/[...slug].astro
@@ -6,7 +6,7 @@ import { stripFilePathAndExtension } from "~/utils/slugUtils";
 
 //generating static paths from en collection
 export async function getStaticPaths() {
-  const docEntries = await getCollection("api-docs");
+  const docEntries = await getCollection("reference-docs");
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {
@@ -15,22 +15,15 @@ export async function getStaticPaths() {
     }),
   );
   return docEntries.map((entry, index) => {
-    //Remove .md extension AND filepath prefix (ex:superoffice-docs/docs/en/api) from filepath
+    //Remove .md extension AND filepath prefix (ex:superoffice-docs/docs/en/api/reference) from filepath
     const generatedSlug = stripFilePathAndExtension(
       entry.filePath!,
-      `superoffice-docs/docs/en/api`,
+      `superoffice-docs/docs/en/api/reference`,
       true,
     );
     
-    const category = generatedSlug?.split("/")[0];
-
-    function getTocPath(): string{
-      if (category == "reference") return `/${generatedSlug.substring(0, generatedSlug.lastIndexOf("/"))}`;
-      return ""
-    }
-
-    const tocPath = getTocPath();
-    const tocData = getTableOfContents(`docs/en/api${tocPath}`);
+    const tocPath = generatedSlug?.split("/")[0];
+    const tocData = getTableOfContents(`docs/en/api/reference/${tocPath}`);
 
     return {
       params: { slug: `${generatedSlug}` },
@@ -46,7 +39,7 @@ const { Content } = await render(entry);
 
 <MarkdownLayout
   frontmatter={entry.data}
-  collection={"api-docs"}
+  collection={"reference-docs"}
   slug={entry.id}
   filePath={entry.filePath}
   headings={headings}

--- a/src/pages/en/api/reference/webapi/[...slug].astro
+++ b/src/pages/en/api/reference/webapi/[...slug].astro
@@ -12,8 +12,7 @@ import type { Item } from "~/types/WebAPITypes";
 import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
 import { stripFilePathAndExtension } from "~/utils/slugUtils";
 
-const language = "en";
-const collectionPath = `superoffice-docs/docs/${language}/api/reference/webapi`;
+const collectionPath = `superoffice-docs/docs/en/api/reference/webapi`;
 const allTocEntries = await getCollection("toc");
 const tocEntries = allTocEntries.filter((entry) =>
   entry.id.startsWith(collectionPath),
@@ -27,15 +26,12 @@ const tocData = await getTableOfContentsFromCollection(
 export async function getStaticPaths() {
   const YMLEntries = await getCollection("webapi");
   return YMLEntries.map((entry) => {
-
     //Remove .yaml or yml extension AND filepath prefix (ex:superoffice-docs/docs/en/api/reference/webapi) from filepath
-    const generatedSlug = stripFilePathAndExtension(entry.filePath!, `superoffice-docs/docs/en/api/reference/webapi`, true);
-    // const generatedSlug = entry.filePath
-    //   ?.replace(
-    //     "external-content/superoffice-docs/docs/en/api/reference/webapi",
-    //     "",
-    //   )
-    //   .replace(".yml", "");
+    const generatedSlug = stripFilePathAndExtension(
+      entry.filePath!,
+      `superoffice-docs/docs/en/api/reference/webapi`,
+      true,
+    );
     return {
       params: { slug: `${generatedSlug}` },
       props: { entry },
@@ -43,7 +39,7 @@ export async function getStaticPaths() {
   });
 }
 
-const { entry} = Astro.props;
+const { entry } = Astro.props;
 const pagetitle = entry.data.items[0].type + " " + entry.data.items[0].id;
 
 // Use to get the plural forms of the name
@@ -83,7 +79,7 @@ if (documentType == "Namespace") {
       }
     },
   );
-
+  
   await Promise.all(promises || []);
 } else if (["Class", "Interface", "Enum"].includes(documentType)) {
   // Append headings of every other item except parent item to headingsList
@@ -150,7 +146,6 @@ function appendIntoHeadingList(key: keyof headingsListProps, dataItem: Item) {
   slug={entry.id}
   TableOfContentData={tocData}
   isLearn={false}
-  isWebAPI={true}
   headings={headings}
   lang="en"
 >


### PR DESCRIPTION
- Defined a separate content collection for markdown files in the docs/en/api/reference folder 
- Created a [...slug].astro for en/api/reference
- Updated TOCPath variable logic in markdown layout (markdown.astro)
- Removed the isWebApiTOC prop that was previously passed into TableOfContentList component