### PR TITLE
#162 enable astro redirect from integration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -113,6 +113,7 @@ export default defineConfig({
   build: {
     format: "preserve",
   },
+  logLevel: process.env.CI ? 'error' : 'info',
   site: "https://superofficedocs.github.io",
   base: "/docs-next",
   trailingSlash: "never",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,6 +16,8 @@ import remarkIncludeDirective from "./src/plugins/AddIncludesToMarkdown.js";
 import remarkRestyleDirective from "./src/plugins/RestyleDirectives.js";
 import react from "@astrojs/react";
 import yaml from '@rollup/plugin-yaml';
+import redirectFrom from "astro-redirect-from";
+import { getRedirectFromSlug } from './src/utils/slugUtils.ts';
 
 // https://astro.build/config
 export default defineConfig({
@@ -86,11 +88,13 @@ export default defineConfig({
       },
     }),
     mdx(),
-    // preact(),
-    robots(),
-    sitemap(),
     pagefind(),
-    react(),
+    react(), // preact(),
+    redirectFrom({
+      contentDir: './external-content',
+      getSlug: getRedirectFromSlug, // Function to get the slug for redirect_from
+    }),
+    robots(), sitemap(),
   ],
   image: {
     service: sharpImageService({ limitInputPixels: false }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "astro-breadcrumbs": "^3.0.0",
         "astro-icon": "^1.1.5",
         "astro-pagefind": "^1.6.0",
+        "astro-redirect-from": "^1.4.0-beta.0",
         "astro-robots": "^2.0.1",
         "astro-social-share": "^2.0.2",
         "dayjs": "^1.11.12",
@@ -2398,6 +2399,18 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
@@ -3028,6 +3041,33 @@
       },
       "peerDependencies": {
         "astro": "^2.0.4 || ^3 || ^4 || ^5"
+      }
+    },
+    "node_modules/astro-redirect-from": {
+      "version": "1.4.0-beta.0",
+      "resolved": "https://registry.npmjs.org/astro-redirect-from/-/astro-redirect-from-1.4.0-beta.0.tgz",
+      "integrity": "sha512-lZTeW/hPZZs6vC5yVakW5RAFjSdNkPzsSeZCqgC2v6ficDPvOiSM+4rk2Be7vVRS2sIYu9yB1G0KspsA3lHQvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/kremalicious"
+        },
+        {
+          "type": "individual",
+          "url": "https://kremalicious.com/thanks"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "globby": "^14.1.0",
+        "gray-matter": "^4.0.3"
+      },
+      "engines": {
+        "astro": ">=3.0.0",
+        "node": "22"
+      },
+      "peerDependencies": {
+        "astro": ">=3.0.0"
       }
     },
     "node_modules/astro-robots": {
@@ -4385,6 +4425,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
@@ -4493,6 +4546,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
@@ -4898,6 +4963,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -4908,6 +4993,43 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/h3": {
@@ -5311,6 +5433,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/import-meta-resolve": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.1.0.tgz",
@@ -5441,6 +5572,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-extglob": {
@@ -5620,6 +5760,15 @@
       "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-2.3.1.tgz",
       "integrity": "sha512-H8jvkz1O50L3dMZCsLqiuB2tA7muqbSg1AtGEkN0leAqGjsUzDJir3Zwr02BhqdcITPg3ei3mZ+HjMocAknhhg==",
       "license": "MIT"
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/kleur": {
       "version": "4.1.5",
@@ -7413,6 +7562,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -8482,6 +8643,19 @@
       "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8657,6 +8831,18 @@
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/smol-toml": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.1.tgz",
@@ -8696,6 +8882,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/stack-trace": {
       "version": "1.0.0-pre2",
@@ -8820,6 +9012,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-indent": {
@@ -9409,6 +9610,18 @@
       "dependencies": {
         "pako": "^0.2.5",
         "tiny-inflate": "^1.0.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "astro-breadcrumbs": "^3.0.0",
     "astro-icon": "^1.1.5",
     "astro-pagefind": "^1.6.0",
+    "astro-redirect-from": "^1.4.0-beta.0",
     "astro-robots": "^2.0.1",
     "astro-social-share": "^2.0.2",
     "dayjs": "^1.11.12",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",
-    "build": "cross-env NODE_OPTIONS='--max-old-space-size=12288' astro check && astro build",
+    "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=12288\" astro check && astro build",
     "normal-build": "astro check && astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/src/pages/de/[...slug].astro
+++ b/src/pages/de/[...slug].astro
@@ -15,7 +15,10 @@ const tocData = await getTableOfContentsFromCollection(tocEntries, `superoffice-
 // Generate static paths from de collection
 export async function getStaticPaths() {
   const language = "de" as const;
-  const docEntries = await getCollection(language);
+  const docEntries = await getCollection(language, ({ data }) => {
+  return !data.redirect_url;
+});
+
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -6,7 +6,9 @@ import { stripFilePathAndExtension } from "~/utils/slugUtils";
 
 //generating static paths from en collection
 export async function getStaticPaths() {
-  const docEntries = await getCollection("en");
+  const docEntries = (await getCollection("en", ({ data }) => {
+    return !data.redirect_url;
+  }));
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {

--- a/src/pages/release-notes/[...slug].astro
+++ b/src/pages/release-notes/[...slug].astro
@@ -16,7 +16,9 @@ const tocData = await getTableOfContentsFromCollection(tocEntries, collectionFul
 // Generate static paths from release-notes collection
 export async function getStaticPaths() {
   const collectionName = "release-notes";
-  const docEntries = await getCollection(collectionName);
+  const docEntries = (await getCollection(collectionName, ({ data }) => {
+    return !data.redirect_url;
+  }));
 
   const headings = await Promise.all(
     docEntries.map(async (post) => {

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -77,6 +77,10 @@ export function extractCategorySlug(id: string, basePath: string): string {
   return rawSlug ? trimFileExtension(rawSlug) : "index";
 }
 
+/**
+ * Used by the `astro-redirect-from` package to generate a redirect slug from a file path.
+ * It determines the collection based on the file path and returns a clean slug.
+ */
 export function getRedirectFromSlug(filePath: string) {
   let collection = "superoffice-docs/docs/en"; // default
 

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -1,15 +1,17 @@
 const supportedExtensions = [".md", ".mdx", ".yml", ".yaml"];
+const contentDir = "external-content"; // external content directory
+const contentRepo = "superoffice-docs"; // primary content repository
 
 /**
- * Strips the slug prefix and file extension from an entry.filePath.
- * For example: "src/content/release-notes/v11/index.md" -> "/v11/index"
+ * Strips the content directory prefix, collection path, and file extension from an entry.filePath.
+ * For example: "external-content/superoffice-docs/docs/en/project/learn/index.md" -> "/project/learn/index"
  */
-export function stripFilePathAndExtension(filePath: string, collection: string, isExternal = false): string {
+export function stripFilePathAndExtension(filePath: string, collection: string, isExternal: boolean = false): string {
   const base = isExternal
-  ? `external-content/${collection}/`
-  : `src/content/${collection}/`;
+  ? `${contentDir}/`
+  : `src/content/`;
 
-  return filePath.replace(base, "").replace(/\.(md|ya?ml)$/, "");
+  return filePath.replace(base, "").replace(`${collection}/`, "").replace(/\.(md|ya?ml)$/, "");
 }
 
 /**
@@ -73,4 +75,21 @@ export function resolveHref(url: string, baseSlug?: string): string {
 export function extractCategorySlug(id: string, basePath: string): string {
   const rawSlug = id === basePath ? "" : id.replace(`${basePath}/`, "");
   return rawSlug ? trimFileExtension(rawSlug) : "index";
+}
+
+export function getRedirectFromSlug(filePath: string) {
+  let collection = "superoffice-docs/docs/en"; // default
+
+  if (filePath.startsWith(`${contentRepo}/docs/`)) {
+    collection = `${contentRepo}/docs/${filePath.split("/")[2]}`;
+  } else if (filePath.startsWith(`${contentRepo}/release-notes/`)) {
+    collection = `${contentRepo}/release-notes`;
+  } else {
+    // For any other repo (contribution, etc.), use the first part of the path
+    collection = filePath.split('/')[0];
+  }
+
+  const slug = stripFilePathAndExtension(filePath!, collection, true);
+  //console.warn(`[getRedirectFromSlug] 🔹 filePath: "${filePath}", collection: "${collection}", slug: "${slug}"`);
+  return slug;
 }


### PR DESCRIPTION
To install: npm i astro-redirect-from@1.4.0-beta.0

Set default log level based on env.
Updated stripFilePathAndExtension() to work both with and without 'external-content' prefix.

The change in the [...slug].astro will prevent Astro from building routes for pages with docfx style redirect_url property. The integration will generate the same routes  - with proper content - and we want to avoid conflicts.

After launching docs-next, we'll delete these redurect_url files.

## Disclaimer

I've been in contact with the developer of this extension. They provided a fix within 5h to the 1st problem I encountered. There's currently a small issue with how the integration handles the base property, and I'm confident it will be fixed before we launch. However, plan B is a simple file copy from folder A to folder B. The contents of the generated redirects are correct.