### PR TITLE
#186 Segment route and rendering of database

### DIFF
--- a/src/pages/de/[...subcategory].astro
+++ b/src/pages/de/[...subcategory].astro
@@ -1,8 +1,7 @@
 ---
 import { getCollection, getEntry, type CollectionEntry } from "astro:content";
-import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
-import { extractCategorySlug } from "~/utils/slugUtils";
-import { getLocalizedToc } from "~/utils/getLocalizedToc";
+import { extractCategorySlug } from "@utils/slugUtils";
+import { getLocalizedToc } from "@utils/tocUtils";
 import SubCategoryLandingLayout from "@layouts/SubCategoryLandingLayout.astro";
 
 type SubCategoryDataType = Extract<
@@ -15,8 +14,7 @@ const collectionPath = `superoffice-docs/docs/${language}` as const;
 
 // Computed tocData once at module load (build-time) and reuse it for all pages.
 // A single TOC for all DE pages, rooted at "learn".
-const tocEntries = await getLocalizedToc(language);
-const ToCData = await getTableOfContentsFromCollection(tocEntries, `${collectionPath}/learn`);
+const tocData = await getLocalizedToc(language);
 
 // Dynamically generate one path per SubCategory YAML this folder:
 export async function getStaticPaths() {
@@ -47,6 +45,6 @@ const CategoryData = entry.data as SubCategoryDataType;
 <SubCategoryLandingLayout
   lang={language}
   data={CategoryData}
-  ToCData={ToCData}
+  ToCData={tocData}
   baseSlug={filePath}
 />

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -1,39 +1,34 @@
 ---
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
+import { getTableOfContents } from "@utils/getTableOfContents";
+import { getFilteredDocEntries, getHeadings } from "@utils/contentUtils";
+import { getContentSlug } from "@utils/slugUtils";
 import MarkdownLayout from "@layouts/Markdown.astro";
-import { getTableOfContents } from "../../utils/getTableOfContents";
-import { stripFilePathAndExtension } from "~/utils/slugUtils";
+
+const language = "en" as const;
 
 //generating static paths from en collection
 export async function getStaticPaths() {
-  const docEntries = (await getCollection("en", ({ data }) => {
-    return !data.redirect_url;
-  }));
+  const language = "en" as const;
+  const excluded = ["database"];
 
-  const headings = await Promise.all(
-    docEntries.map(async (post) => {
-      const data = await render(post);
-      return data.headings;
-    }),
-  );
+  // No redirects and not in excluded folders
+  const docEntries = await getFilteredDocEntries(language, excluded);
+  const headings = await getHeadings(docEntries);
+
   return docEntries.map((entry, index) => {
-    //Remove .md extension AND filepath prefix (ex:superoffice-docs/docs/en) from filepath
-    const generatedSlug = stripFilePathAndExtension(
-      entry.filePath!,
-      `superoffice-docs/docs/en`,
-      true,
-    );
-    
+    const generatedSlug = getContentSlug(entry.filePath!, language);
+
     const category = generatedSlug?.split("/")[0];
     const isLearn = entry.data.uid?.startsWith("help");
 
-    function getTocPath(): string{
+    function getTocPath(): string {
       if (isLearn) return "learn";
       return category;
     }
 
     const tocPath = getTocPath();
-    const tocData = getTableOfContents(`docs/en/${tocPath}`);
+    const tocData = getTableOfContents(`docs/${language}/${tocPath}`);
 
     return {
       params: { slug: `${generatedSlug}` },
@@ -55,7 +50,7 @@ const { Content } = await render(entry);
   headings={headings}
   TableOfContentData={tocData}
   isLearn={isLearn}
-  lang="en"
+  lang={language}
 >
   {Content ? <Content /> : "Loading content..."}
 </MarkdownLayout>

--- a/src/pages/en/database/[...slug].astro
+++ b/src/pages/en/database/[...slug].astro
@@ -1,25 +1,27 @@
 ---
 import { render, type CollectionEntry } from "astro:content";
 import type { MarkdownHeading } from "astro";
-import { getHeadings, getDocEntries } from "@utils/contentUtils";
-import { getLocalizedToc } from "@utils/tocUtils";
+import { getSegmentToc } from "@utils/tocUtils";
+import { getDocEntries, getHeadings } from "@utils/contentUtils";
 import { getContentSlug } from "@utils/slugUtils";
 import MarkdownLayout from "@layouts/Markdown.astro";
 
-const language = "de" as const;
+const language = "en" as const;
+const segment = "database" as const;
 
 // Computed tocData once at module load (build-time) and reuse it for all pages
-const tocData = await getLocalizedToc(language);
+const tocData = getSegmentToc(language, segment);
 
 // Generate static paths from de collection
 export async function getStaticPaths() {
-  const language = "de" as const;
+  const language = "en" as const;
+  const segment = "database" as const;
 
-  const docEntries = await getDocEntries(language);
+  const docEntries = await getDocEntries(language, segment);
   const headings = await getHeadings(docEntries);
 
   return docEntries.map((entry, index) => {
-    const generatedSlug = getContentSlug(entry.filePath!, language);
+    const generatedSlug = getContentSlug(entry.filePath!, language, segment);
 
     return {
       params: { slug: `${generatedSlug}` },
@@ -44,7 +46,7 @@ const { Content } = await render(entry);
   slug={entry.id}
   headings={headings}
   TableOfContentData={tocData}
-  isLearn="true"
+  isLearn="false"
   lang={language}
 >
   {Content ? <Content /> : "Loading content..."}

--- a/src/utils/contentUtils.ts
+++ b/src/utils/contentUtils.ts
@@ -1,0 +1,65 @@
+import { getCollection, render, type CollectionEntry, type DataEntryMap } from 'astro:content';
+import type { MarkdownHeading } from 'astro';
+
+const contentRoot = 'superoffice-docs/docs';
+
+/**
+ * Fetches all non-redirect entries in a language, or—if `folder` is provided—only those under that folder.
+ *
+ * @param language - The Astro collection key, such as "en", "de".
+ * @param folder?  - Optional sub-folder name to include, for example "database".
+ *                   When omitted, returns every non-redirect entry.
+ * @returns A promise resolving to the filtered array of `CollectionEntry<language>`.
+ */
+export async function getDocEntries<L extends keyof DataEntryMap>(
+  language: L,
+  folder?: string
+): Promise<CollectionEntry<L>[]> {
+  const base = `${contentRoot}/${language}`;
+  return getCollection(language, ({ id, data }) =>
+    !data.redirect_url &&
+    (!folder || id.includes(`/${folder}/`))
+  );
+}
+
+/**
+ * Fetches all non-redirect entries in a language, omitting any that live under the named folders.
+ *
+ * @param language      - The Astro collection key, such as "en", "de".
+ * @param excludeFolders - Array of sub-folder names to skip entirely,
+ *                         for example, `["database", "onsite"]`.
+ * @returns A promise resolving to the filtered array of `CollectionEntry<language>`.
+ */
+export async function getFilteredDocEntries<L extends keyof DataEntryMap>(
+  language: L,
+  excludeFolders: string[]
+): Promise<CollectionEntry<L>[]> {
+  const base = `${contentRoot}/${language}`;
+  const skipRe = new RegExp(`^${base}(?:${excludeFolders.join("|")})(?:/|$)`);
+
+  return getCollection(language, ({ id, data }) =>
+    !data.redirect_url &&
+    !skipRe.test(id)
+  );
+}
+
+
+/**
+ * Renders a list of content entries and extracts their Markdown headings.
+ *
+ * Useful for generating an array of page‐specific TOC headings in `getStaticPaths` or similar data loaders.
+ * The generic `<T extends keyof DataEntryMap>` preserves the concrete collection key (such as "en", "de") for full type safety.
+ *
+ * @param entries - An array of `CollectionEntry<T>` items from Astro's content collections.
+ * @returns A promise that resolves to an array of `MarkdownHeading[]`, where each inner array corresponds to the headings of one entry.
+ */
+export async function getHeadings<T extends keyof DataEntryMap>(
+  entries: CollectionEntry<T>[]
+): Promise<MarkdownHeading[][]> {
+  return Promise.all(
+    entries.map(async (post) => {
+      const { headings } = await render(post);
+      return headings;
+    })
+  );
+}

--- a/src/utils/getLocalizedToc.ts
+++ b/src/utils/getLocalizedToc.ts
@@ -1,8 +1,0 @@
-import { getCollection, type CollectionEntry } from "astro:content";
-
-export async function getLocalizedToc(language: string): Promise<CollectionEntry<"toc">[]> {
-  const tocEntries = await getCollection("toc", ({ id }) =>
-    id.startsWith(`superoffice-docs/docs/${language}`)
-  );
-  return tocEntries;
-}

--- a/src/utils/slugUtils.ts
+++ b/src/utils/slugUtils.ts
@@ -63,6 +63,32 @@ export function resolveHref(url: string, baseSlug?: string): string {
 }
 
 /**
+ * Gets a clean route slug from an Astro content entry.filePath.
+ *
+ * Strips off the common repo/folder prefix (`superoffice-docs/docs/{language}`)
+ * and, if provided, an extra `/{segment}` folder, and then removes the file extension.
+ *
+ * @param filePath - The raw `entry.filePath`,  such as "superoffice-docs/docs/en/database/index.md".
+ * @param language - The locale folder, such as "en", "de".
+ * @param segment? - Optional subfolder under the language, for example "database".
+ *                   If omitted, only the language folder is stripped.
+ * @returns A slug string such as "foo" or "bar/index".
+ */
+export function getContentSlug(
+  filePath: string,
+  language: string,
+  segment?: string
+): string {
+  const base = `${contentRepo}/docs`;
+  const prefix = segment
+    ? `${base}/${language}/${segment}`
+    : `${base}/${language}`;
+
+  // strip prefix and extension
+  return stripFilePathAndExtension(filePath, prefix, true);
+}
+
+/**
  * Extracts the clean slug from a full file ID by removing the base path and file extension.
  *
  * Useful for generating route parameters for category and subcategory pages from landing entry IDs, such as converting

--- a/src/utils/tocUtils.ts
+++ b/src/utils/tocUtils.ts
@@ -1,0 +1,34 @@
+import { getCollection } from 'astro:content';
+import { getTableOfContentsFromCollection } from '~/utils/getTableOfContentsFromCollection';
+
+const root = 'superoffice-docs/docs';
+
+/**
+ * Builds a table-of-contents data structure for all pages under a given
+ * language/segment, computing once at build-time.
+ *
+ * @param language - The Astro content collection key, such as "en".
+ * @param segment  - The sub-folder name under `superoffice-docs/docs/{language}`, for example "database".
+ * @returns A promise resolving to the ToC data array for `/…/{segment}`.
+ */
+export async function getSegmentToc(
+    language: string,
+    segment: string
+) {
+    const base = `${root}/${language}/${segment}`;
+    const tocEntries = await getCollection('toc', (e) => e.id.startsWith(base));
+    return getTableOfContentsFromCollection(tocEntries, base);
+}
+
+/**
+ * Builds a table-of-contents data structure for the **fixed** "learn" segment
+ * under a given language, computing once at build-time.
+ *
+ * @param language - The Astro content collection key, such as "en".
+ * @returns A promise resolving to the ToC data array for `/{language}/learn`.
+ */
+export async function getLocalizedToc(language: string) {
+    const base = `${root}/${language}/learn`;
+    const tocEntries = await getCollection('toc', (e) => e.id.startsWith(base));
+    return getTableOfContentsFromCollection(tocEntries, base);
+}


### PR DESCRIPTION
- Refactor common functionality in [...slug].astro
- Add contentUtils.ts and tocUtils.ts (includes getLocalizedToc.ts)
- Add getContentSlug() to slugUtils.ts
- Use path alias "@utils/slugUtils"

Using the term "segment" to denote a subset of content that lives at the language root, has its own toc tree, and so on - to not confuse it with a category or a category/subcategory page. Yes, there is a strong likeness, but not a 1:1 mapping.

Database is the first of many segments to be split off for route generation and rendering to lower the memory requirements. The refactoring reduces the code duplication across segments/languages and makes it easier to maintain.