### PR TITLE
#195 Add MarkdownPage wrapper component

### DIFF
--- a/src/components/MarkdownPage.astro
+++ b/src/components/MarkdownPage.astro
@@ -1,0 +1,28 @@
+---
+import { render, type CollectionEntry, type DataEntryMap } from 'astro:content';
+import type { MarkdownHeading } from 'astro';
+import MarkdownLayout from '@layouts/Markdown.astro';
+
+export interface Props {
+  /** Accept an entry from *any* collection our site defines */
+  entry: CollectionEntry<keyof DataEntryMap>;
+  headings: MarkdownHeading[];
+  toc: unknown;
+  isLearn?: boolean;
+  language: string;
+}
+
+const { entry, headings, toc, isLearn = false, language } = Astro.props;
+const { Content } = await render(entry);
+---
+<MarkdownLayout
+  frontmatter={entry.data}
+  collection={entry.collection}
+  slug={entry.id}
+  headings={headings}
+  TableOfContentData={toc}
+  isLearn={isLearn.toString()}
+  lang={language}
+>
+  {Content && <Content />}
+</MarkdownLayout>

--- a/src/pages/contribute/[...slug].astro
+++ b/src/pages/contribute/[...slug].astro
@@ -1,27 +1,18 @@
 ---
-import type { CollectionEntry } from "astro:content";
-import type { MarkdownHeading } from "astro";
-import { getCollection, render } from "astro:content";
-import { stripFilePathAndExtension } from "~/utils/slugUtils";
-import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
-import MarkdownLayout from "@layouts/Markdown.astro";
+import { getCollection } from "astro:content";
+import { stripFilePathAndExtension } from "@utils/slugUtils";
+import { getHeadings } from "@utils/contentUtils";
+import { getTocByPath } from "@utils/tocUtils";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
-const collectionPath = "contribution";
-const allTocEntries = await getCollection("toc");
-const tocEntries = allTocEntries.filter((entry) =>
-  entry.id.startsWith(collectionPath)
-);
-const tocData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
+const language = "en" as const;
+
+const tocData = await getTocByPath('contribution');
 
 export async function getStaticPaths() {
   const docEntries = await getCollection("contribute");
 
-  const headings = await Promise.all(
-    docEntries.map(async (entry) => {
-      const rendered = await render(entry);
-      return rendered.headings;
-    })
-  );
+  const headings = await getHeadings(docEntries);
 
   const paths = docEntries.map((entry, index) => {
     const slug = stripFilePathAndExtension(entry.filePath!, "contribution", true);
@@ -35,25 +26,12 @@ export async function getStaticPaths() {
   return paths;
 }
 
-type Props = {
-  entry: CollectionEntry<"contribute">;
-  headings: MarkdownHeading[];
-};
-
 const { entry, headings } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
-  filePath={entry.filePath}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
-  isLearn={false}
-  lang="en"
->
-  {Content ? <Content /> : "Loading..."}
-</MarkdownLayout>
+  toc={tocData}
+  language={language}
+/>

--- a/src/pages/de/[...slug].astro
+++ b/src/pages/de/[...slug].astro
@@ -1,10 +1,8 @@
 ---
-import { render, type CollectionEntry } from "astro:content";
-import type { MarkdownHeading } from "astro";
 import { getHeadings, getDocEntries } from "@utils/contentUtils";
 import { getLocalizedToc } from "@utils/tocUtils";
 import { getContentSlug } from "@utils/slugUtils";
-import MarkdownLayout from "@layouts/Markdown.astro";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
 const language = "de" as const;
 
@@ -28,24 +26,13 @@ export async function getStaticPaths() {
   });
 }
 
-type Props = {
-  entry: CollectionEntry<typeof language>;
-  headings: MarkdownHeading[];
-};
-
 const { entry, headings } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
-  isLearn="true"
-  lang={language}
->
-  {Content ? <Content /> : "Loading content..."}
-</MarkdownLayout>
+  toc={tocData}
+  language={language}
+  isLearn={true}
+/>

--- a/src/pages/en/[...slug].astro
+++ b/src/pages/en/[...slug].astro
@@ -1,9 +1,8 @@
 ---
-import { render } from "astro:content";
 import { getTableOfContents } from "@utils/getTableOfContents";
 import { getFilteredDocEntries, getHeadings } from "@utils/contentUtils";
 import { getContentSlug } from "@utils/slugUtils";
-import MarkdownLayout from "@layouts/Markdown.astro";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
 const language = "en" as const;
 
@@ -31,26 +30,19 @@ export async function getStaticPaths() {
     const tocData = getTableOfContents(`docs/${language}/${tocPath}`);
 
     return {
-      params: { slug: `${generatedSlug}` },
+      params: { slug: generatedSlug },
       props: { entry, headings: headings[index], tocData, isLearn },
     };
   });
 }
 
 const { entry, headings, tocData, isLearn } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
-  filePath={entry.filePath}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
+  toc={tocData}
+  language={language}
   isLearn={isLearn}
-  lang={language}
->
-  {Content ? <Content /> : "Loading content..."}
-</MarkdownLayout>
+/>

--- a/src/pages/en/database/[...slug].astro
+++ b/src/pages/en/database/[...slug].astro
@@ -1,16 +1,14 @@
 ---
-import { render, type CollectionEntry } from "astro:content";
-import type { MarkdownHeading } from "astro";
 import { getSegmentToc } from "@utils/tocUtils";
 import { getDocEntries, getHeadings } from "@utils/contentUtils";
 import { getContentSlug } from "@utils/slugUtils";
-import MarkdownLayout from "@layouts/Markdown.astro";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
 const language = "en" as const;
 const segment = "database" as const;
 
 // Computed tocData once at module load (build-time) and reuse it for all pages
-const tocData = getSegmentToc(language, segment);
+const tocData = await getSegmentToc(language, segment);
 
 // Generate static paths from de collection
 export async function getStaticPaths() {
@@ -24,30 +22,18 @@ export async function getStaticPaths() {
     const generatedSlug = getContentSlug(entry.filePath!, language, segment);
 
     return {
-      params: { slug: `${generatedSlug}` },
+      params: { slug: generatedSlug },
       props: { entry, headings: headings[index] },
     };
   });
 }
 
-type Props = {
-  entry: CollectionEntry<typeof language>;
-  headings: MarkdownHeading[];
-};
-
 const { entry, headings } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
-  isLearn="false"
-  lang={language}
->
-  {Content ? <Content /> : "Loading content..."}
-</MarkdownLayout>
+  toc={tocData}
+  language={language}
+/>

--- a/src/pages/en/developer-portal/[...slug].astro
+++ b/src/pages/en/developer-portal/[...slug].astro
@@ -1,16 +1,14 @@
 ---
-import { render, type CollectionEntry } from "astro:content";
-import type { MarkdownHeading } from "astro";
 import { getSegmentToc } from "@utils/tocUtils";
 import { getDocEntries, getHeadings } from "@utils/contentUtils";
 import { getContentSlug } from "@utils/slugUtils";
-import MarkdownLayout from "@layouts/Markdown.astro";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
 const language = "en" as const;
 const segment = "developer-portal" as const;
 
 // Computed tocData once at module load (build-time) and reuse it for all pages
-const tocData = getSegmentToc(language, segment);
+const tocData = await getSegmentToc(language, segment);
 
 // Generate static paths from de collection
 export async function getStaticPaths() {
@@ -24,30 +22,18 @@ export async function getStaticPaths() {
     const generatedSlug = getContentSlug(entry.filePath!, language, segment);
 
     return {
-      params: { slug: `${generatedSlug}` },
+      params: { slug: generatedSlug },
       props: { entry, headings: headings[index] },
     };
   });
 }
 
-type Props = {
-  entry: CollectionEntry<typeof language>;
-  headings: MarkdownHeading[];
-};
-
 const { entry, headings } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
-  isLearn="false"
-  lang={language}
->
-  {Content ? <Content /> : "Loading content..."}
-</MarkdownLayout>
+  toc={tocData}
+  language={language}
+/>

--- a/src/pages/release-notes/[...slug].astro
+++ b/src/pages/release-notes/[...slug].astro
@@ -1,61 +1,39 @@
 ---
-import { getCollection, render } from "astro:content";
-import type { CollectionEntry } from "astro:content";
-import type { MarkdownHeading } from "astro";
-import MarkdownLayout from "@layouts/Markdown.astro";
-import { stripFilePathAndExtension } from "~/utils/slugUtils";
-import { getTableOfContentsFromCollection } from "~/utils/getTableOfContentsFromCollection";
+import { getCollection } from "astro:content";
+import { stripFilePathAndExtension } from "@utils/slugUtils";
+import { getHeadings } from "@utils/contentUtils";
+import { getTocByPath } from "@utils/tocUtils";
+import MarkdownPage from "@components/MarkdownPage.astro";
 
-const collectionFullName = `superoffice-docs/release-notes`;
-const allTocEntries = await getCollection("toc");
-const tocEntries = allTocEntries.filter((entry) =>
-  entry.id.startsWith(collectionFullName)
-);
-const tocData = await getTableOfContentsFromCollection(tocEntries, collectionFullName);
+const language = "en" as const;
+
+const tocData = await getTocByPath('superoffice-docs/release-notes');
 
 // Generate static paths from release-notes collection
 export async function getStaticPaths() {
-  const collectionName = "release-notes";
-  const docEntries = (await getCollection(collectionName, ({ data }) => {
+  const collection = "release-notes";
+  const docEntries = (await getCollection(collection, ({ data }) => {
     return !data.redirect_url;
   }));
 
-  const headings = await Promise.all(
-    docEntries.map(async (post) => {
-      const data = await render(post);
-      return data.headings;
-    })
-  );
+  const headings = await getHeadings(docEntries);
 
   return docEntries.map((entry, index) => {
-
-    //Remove .md extension AND filepath prefix (ex:superoffice-docs/release-notes) from filepath
-    const generatedSlug = stripFilePathAndExtension(entry.filePath!, `superoffice-docs/${collectionName}`, true);
+    const generatedSlug = stripFilePathAndExtension(entry.filePath!, `superoffice-docs/${collection}`, true);
 
     return {
-      params: { slug: `${generatedSlug}` },
+      params: { slug: generatedSlug },
       props: { entry, headings: headings[index] },
     };
   });
 }
 
-type Props = {
-  entry: CollectionEntry<"release-notes">;
-  headings: MarkdownHeading[];
-};
-
 const { entry, headings } = Astro.props;
-
-const { Content } = await render(entry);
 ---
 
-<MarkdownLayout
-  frontmatter={entry.data}
-  collection={entry.collection}
-  slug={entry.id}
+<MarkdownPage
+  entry={entry}
   headings={headings}
-  TableOfContentData={tocData}
-  lang="en"
->
-  {Content ? <Content /> : "Loading content..."}
-</MarkdownLayout>
+  toc={tocData}
+  language={language}
+/>

--- a/src/utils/tocUtils.ts
+++ b/src/utils/tocUtils.ts
@@ -32,3 +32,17 @@ export async function getLocalizedToc(language: string) {
     const tocEntries = await getCollection('toc', (e) => e.id.startsWith(base));
     return getTableOfContentsFromCollection(tocEntries, base);
 }
+
+/**
+ * Builds a table‐of‐contents data array for any collection base path,
+ * computing once at build-time. Handles special cases.
+ *
+ * @param basePath - The full prefix, for example "superoffice-docs/release-notes", or "contribution".
+ * @returns A Promise resolving to the ToC data array for that path.
+ */
+export async function getTocByPath(path: string) {
+  const tocEntries = await getCollection('toc', (e) =>
+    e.id.startsWith(path)
+  );
+  return getTableOfContentsFromCollection(tocEntries, path);
+}


### PR DESCRIPTION
Refactor all non-api routes
Add getTocByPath for special cases like contribution and release-notes (when files are outside docs/LANG.

The new wrapper handles the rendering and sets isLearn=false by default. It reduces the code from

```
<MarkdownLayout
  frontmatter={entry.data}
  collection={entry.collection}
  slug={entry.id}
  headings={headings}
  TableOfContentData={tocData}
  isLearn="false"
  lang={language}
>
  {Content ? <Content /> : "Loading content..."}
</MarkdownLayout>
```

to
```
<MarkdownPage
  entry={entry}
  headings={headings}
  toc={tocData}
  language={language}
/>
```
And makes it easier to refactor MarkdownLayout in the future.
