### PR TITLE
#211 Add netserver-scripting reference

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -43,6 +43,17 @@ const apiDocs = defineCollection({
  * API REFERENCES
  */
 
+const NSScriptingRef = defineCollection({
+  loader: glob({
+    pattern: apiOnly ? [
+      "**/*.md",
+      "!**/includes/**",
+    ] : [""] ,
+    base: "external-content/superoffice-docs/docs/en/automation/netserver-scripting/reference",
+  }),
+  schema: DocsSchema,
+});
+
 const referenceDocs = defineCollection({
   loader: glob({
     pattern: apiOnly ? [
@@ -178,6 +189,7 @@ export const collections = {
   no: noDocs,
   sv: svDocs,
   "api-docs": apiDocs,
+  "nsscripting": NSScriptingRef,
   "reference-docs" : referenceDocs,
   webapi: WebAPI,
   contribute: contribution,

--- a/src/pages/en/automation/netserver-scripting/[...slug].astro
+++ b/src/pages/en/automation/netserver-scripting/[...slug].astro
@@ -1,0 +1,43 @@
+---
+import { getCollection } from "astro:content";
+import { getSegmentToc } from "@utils/tocUtils";
+import { getHeadings } from "@utils/contentUtils";
+import { stripFilePathAndExtension } from "~/utils/slugUtils";
+import MarkdownPage from "@components/MarkdownPage.astro";
+
+const language = "en" as const;
+const segment = "automation" as const;
+
+// Same toc as for automation segment
+const tocData = await getSegmentToc(language, segment);
+
+export async function getStaticPaths() {
+  const collection = "nsscripting" as const;
+  const referencePath = "superoffice-docs/docs/en/automation/netserver-scripting" as const;
+
+  const docEntries = await getCollection(collection);
+  const headings = await getHeadings(docEntries);
+
+  return docEntries.map((entry, index) => {
+    const generatedSlug = stripFilePathAndExtension(
+        entry.filePath!,
+        referencePath,
+        true,
+      );
+
+    return {
+      params: { slug: generatedSlug },
+      props: { entry, headings: headings[index] },
+    };
+  });
+}
+
+const { entry, headings } = Astro.props;
+---
+
+<MarkdownPage
+  entry={entry}
+  headings={headings}
+  toc={tocData}
+  language={language}
+/>


### PR DESCRIPTION
Collection: nsscripting
Routes: auomation/netserver-scripting/[...slug].astro

## Result

Pages are rendered under en/automation/netserver-scripting/reference in api-only build.

<img width="2222" height="649" alt="image" src="https://github.com/user-attachments/assets/c674d83e-8238-4019-9438-9b7ac261ce49" />
<img width="1329" height="746" alt="image" src="https://github.com/user-attachments/assets/8ff49da3-76a8-4568-8010-b21658b6823b" />
<img width="2210" height="1202" alt="image" src="https://github.com/user-attachments/assets/2b4c0350-58c2-4be9-9826-167c1a69b775" />

## Known bugs

* Markdown layout does not resolve links on `[AIAgent](aiagent/index.md)` format
* Toc does not list reference files

Both of these issues pertain to other components and are not specific to netserver-scripting.
