### PR TITLE
fix: removed toString method on isLearn variable in markdown

### DIFF
--- a/src/components/MarkdownPage.astro
+++ b/src/components/MarkdownPage.astro
@@ -21,7 +21,7 @@ const { Content } = await render(entry);
   slug={entry.id}
   headings={headings}
   TableOfContentData={toc}
-  isLearn={isLearn.toString()}
+  isLearn={isLearn}
   lang={language}
 >
   {Content && <Content />}


### PR DESCRIPTION
- removed toString method on isLearn variable in markdown which caused incorrect links in the TOC