### PR TITLE
feat: revamp page header

### DIFF
--- a/src/components/EditPage.astro
+++ b/src/components/EditPage.astro
@@ -1,5 +1,5 @@
 ---
-import { getEditHref } from "@scripts/utils";
+import { getEditHref } from "@utils/headerUtils";
 
 export interface Props {
   docurl: string;

--- a/src/components/Feedback.astro
+++ b/src/components/Feedback.astro
@@ -1,5 +1,5 @@
 ---
-import { getFeedbackHref } from "@scripts/utils";
+import { getFeedbackHref } from "@utils/headerUtils";
 
 export interface Props {
   docurl: string;

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
 import { Icon } from "astro-icon/components";
 import Hamburger from "./Hamburger.astro";
 import logo from "@assets/logo.svg";
-import { trimSlash } from "@scripts/utils";
+import { trimSlash } from "@utils/headerUtils";
 
 const base = import.meta.env.BASE_URL;
 

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -31,7 +31,7 @@ if(isWebApi) {
   filePathUrl = liveUrl.replace("/docs-next/", "src/content/docs/").concat(".yml");
 }
 else{
-  filePathUrl = filePath;
+  filePathUrl = filePath.replace("external-content/superoffice-docs/","");
 }
 
 ---

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -18,21 +18,12 @@ export interface Props {
     uid: string;
   };
   isLearnCategoryPage: boolean;
-  collection: string;
 }
 
-const { filePath, metadata, isLearnCategoryPage, collection } = Astro.props;
+const { filePath, metadata, isLearnCategoryPage } = Astro.props;
 const { title, description, uid } = metadata;
 const isHelp = uid?.split("-")[0] == "help";
-const isWebApi = collection == "webapi"
-var filePathUrl = "";
-
-if(isWebApi) {
-  filePathUrl = liveUrl.replace("/docs-next/", "src/content/docs/").concat(".yml");
-}
-else{
-  filePathUrl = filePath.replace("external-content/superoffice-docs/","");
-}
+const filePathUrl = filePath.replace("external-content/superoffice-docs/","");
 
 ---
 

--- a/src/components/WebApiPage.astro
+++ b/src/components/WebApiPage.astro
@@ -123,7 +123,7 @@ function appendIntoHeadingList(key: keyof headingsListProps, dataItem: Item) {
     toc={tocData}
     isLearn={false}
     language="en"
-/>
+>
     <div class="w-full overflow-x-hidden [&&]:not-prose">
         <h1 class="text-3xl md:text-4xl break-words mt-6 mb-6">{pageTitle}</h1>
 

--- a/src/layouts/CategoryLandingLayout.astro
+++ b/src/layouts/CategoryLandingLayout.astro
@@ -30,7 +30,7 @@ type Props = {
   <div class="relative">
 
     {category == "learn" && ( 
-      <PageHeader collection={collection} filePath={currentPath} metadata={metadata} isLearnCategoryPage={true}/>) }
+      <PageHeader filePath={currentPath} metadata={metadata} isLearnCategoryPage={true}/>) }
 
     <!-- Top Banner -->
     <div

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -52,7 +52,6 @@ const { Content, headings } = entry
       isLearnCategoryPage={false}
       filePath={filePath ?? ""}
       metadata={frontmatter}
-      collection={collection}
     />
   </div>
   <article class="w-full pt-1 article grid grid-cols-12">
@@ -85,6 +84,7 @@ const { Content, headings } = entry
             <div class="prose max-w-none" set:html={htmlEntry.html} />
           )
         }
+        <slot />
       </main>
     </div>
     <div

--- a/src/layouts/YamlManagedReference.astro
+++ b/src/layouts/YamlManagedReference.astro
@@ -25,7 +25,6 @@ const { headings } = await render(entry);
       isLearnCategoryPage={false}
       filePath={filePath}
       metadata={frontmatter}
-      collection={collection}
     />
   </div>
   <article class="w-full pt-1 article grid grid-cols-12">

--- a/src/pages/en/api/reference/[...slug].astro
+++ b/src/pages/en/api/reference/[...slug].astro
@@ -63,8 +63,12 @@ export async function getStaticPaths() {
   }
 
   try {
-    // Temporary configured to only pick restful until github pages limitation is solved
-    const pattern = "superoffice-docs/docs/en/api/reference/restful/**/*.{md,mdx}";
+    // Temporary configured to exclude "soap" until github pages limitation is solved
+    const pattern = [
+      "superoffice-docs/docs/en/api/reference/restful/**/*.{md,mdx}",
+      "superoffice-docs/docs/en/api/reference/{webapi,web,netserver}/**/*.{md,mdx}",
+      "!**/includes/**/*.{md,mdx}"
+    ];
     const filePaths = await glob(pattern, {
       cwd: baseContentPath,
       absolute: false,

--- a/src/utils/headerUtils.ts
+++ b/src/utils/headerUtils.ts
@@ -1,5 +1,5 @@
 export const githubBaseUrl = 'https://github.com/SuperOfficeDocs/';
-export const baseGithubUrl = `${githubBaseUrl}docs-next/blob/main/`;
+export const baseGithubUrl = `${githubBaseUrl}superoffice-docs/blob/main/`;
 export const newIssueUrl = `${githubBaseUrl}feedback/issues/new`;
 
 export const trim = (str = '', ch?: string) => {


### PR DESCRIPTION
- Changed the default repo when redirecting to the relevant file from the Edit and Feedback buttons from SuperOfficeDocs/docs-next to SuperOfficeDocs/superoffice-docs due to currently sourcing files directly from the superoffice-docs repo when building.

-  fixed a few bugs related to WebAPI and markdown layout

#### Code Changes

- Moved and renamed scripts/util.ts to utils/headerUtils.ts
- Changed GitHub repo URL from the docs-next repo to superoffice-docs in headerUtils.ts
- Changed the logic to generate the filePathUrl variable in PageHeader, which is used for Edit and Feedback.
- Changed the markdown component in WebApiPage
- Added `<slot/>` to markdown layout
- Updated api/reference pattern to only exclude "soap" folder 