### PR TITLE
fix: page header disappearing issue and UI glitch

### DIFF
--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -36,7 +36,7 @@ const filePathUrl = filePath.replace("external-content/superoffice-docs/","");
       class="lg:col-span-8 py-2 flex items-center justify-self-start text-superOfficeGreen"
     >
       <Breadcrumbs
-        customizeListElements={[{ index: 1, remove: true }]}
+        customizeListElements={[{index:0, remove:true},{ index: 1, remove: true }]}
       >
         <svg
           slot="separator"
@@ -66,9 +66,11 @@ const filePathUrl = filePath.replace("external-content/superoffice-docs/","");
         )
       }
       {
-        !(isLearnCategoryPage) && (<Share description={description} title={title} />
-      <Feedback docurl={filePathUrl} title={title} uid={uid} />
-      <Edit docurl={filePathUrl} />)
+        !(isLearnCategoryPage) && (
+          <Share description={description} title={title} />
+          <Feedback docurl={filePathUrl} title={title} uid={uid} />
+          <Edit docurl={filePathUrl} />
+        )
       }
     </div>
   </div>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -28,11 +28,11 @@ const { metadata, lang = "en", scroll = true } = Astro.props;
     <ClientRouter />
   </head>
   <body class="h-screen flex flex-col overflow-hidden">
-    <div class="z-50"><Header {...headerData} /></div>
     <div
       class=`min-h-screen ${scroll && "overflow-y-auto"}`
       data-scroll-container
     >
+      <div class="z-50 sticky top-0"><Header {...headerData} /></div>
       <main class="flex-grow mb-[140px] md:mb-[120px]">
         <slot />
       </main>

--- a/src/layouts/Markdown.astro
+++ b/src/layouts/Markdown.astro
@@ -47,7 +47,7 @@ const { Content, headings } = entry
 ---
 
 <Base metadata={frontmatter} lang={language}>
-  <div class="sticky top-0">
+  <div class="z-40 sticky top-[57px]">
     <PageHeader
       isLearnCategoryPage={false}
       filePath={filePath ?? ""}

--- a/src/styles/VideoEmbeddingStyles.css
+++ b/src/styles/VideoEmbeddingStyles.css
@@ -13,4 +13,5 @@ div.embeddedvideo iframe {
   bottom: 0;
   width: 100%;
   height: 100%;
+  z-index: 0;
 }


### PR DESCRIPTION
- Fixed the Page Header disappearing issue when clicking on an item in the OnThisArticle component
- Fixed Page Header UI glitch which clashes with the OnThisArticle component - Fixes #120 
- Removed Home in Breadcrumb menu to adhere to spec (See below image)

<img width="1900" height="592" alt="image" src="https://github.com/user-attachments/assets/d904d2d3-e9ed-4576-a6ca-648ec5b4e83d" />
