### PR TITLE
feat: created a build script to split build locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
 # build output
 dist/
+
+.distA/
+.distB/
+
+
 # generated types
 .astro/
 

--- a/build/local-build-script.mjs
+++ b/build/local-build-script.mjs
@@ -1,0 +1,35 @@
+import { execSync } from "child_process";
+import { cpSync, rmSync, existsSync } from "fs";
+import path from "path";
+
+// Paths
+const distDir = path.resolve("dist");
+const distA = path.resolve(".distA");
+const distB = path.resolve(".distB");
+
+// Cleanup old dirs
+[distDir, distA, distB].forEach((dir) => {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+});
+
+// First build with API_ONLY=true
+console.log("Building with API_ONLY=true");
+execSync("cross-env API_ONLY=false astro build", { stdio: "inherit" });
+cpSync(distDir, distA, { recursive: true });
+
+// Second build with API_ONLY=false
+console.log("Building with API_ONLY=false");
+execSync("cross-env API_ONLY=false astro build", { stdio: "inherit" });
+cpSync(distDir, distB, { recursive: true });
+
+// Merge outputs
+console.log("Merging distA and distB into dist...");
+cpSync(distA, distDir, { recursive: true });
+cpSync(distB, distDir, { recursive: true });
+
+// Pagefind Indexing
+console.log("Indexing with Pagefind");
+execSync("npx pagefind --site dist", { stdio: "inherit" });
+
+
+console.log("Completed. Final merged build is in dist/");

--- a/build/local-build-script.mjs
+++ b/build/local-build-script.mjs
@@ -27,9 +27,13 @@ console.log("Merging distA and distB into dist...");
 cpSync(distA, distDir, { recursive: true });
 cpSync(distB, distDir, { recursive: true });
 
+// Cleanup tempory dir adter merging
+[distA, distB].forEach((dir) => {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+});
+
 // Pagefind Indexing
 console.log("Indexing with Pagefind");
 execSync("npx pagefind --site dist", { stdio: "inherit" });
-
 
 console.log("Completed. Final merged build is in dist/");

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "astro dev",
     "start": "astro dev",
     "build": "cross-env NODE_OPTIONS=\"--max-old-space-size=12288\" astro check && astro build",
-    "normal-build": "astro check && astro build",
+    "build:default": "astro check && astro build",
+    "build:local" : "node build/local-build-script.mjs",
     "preview": "astro preview",
     "astro": "astro",
     "test:e2e": "npm run test --workspace=e2e-tests"

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -17,6 +17,7 @@ export interface Props {
 const { metadata, lang = "en", scroll = true } = Astro.props;
 ---
 
+<!DOCTYPE html>
 <html>
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
- Created build/local-build-script.mjs to run a split build locally using API_ONLY environment variable. 
- Updated command to run local split build  `npm run build:local` in package.json
- Updated command to run default build to `npm run build:default`  in package.json
- Added `<!DOCTYPE html>` tag to base layout
- Updated .gitignore to ignore temporary build folders .distA and .distB 
(which should get deleted when local-build-script.mjs is completed. They may remain if the build script run is incomplete.)