### PR TITLE
feat: integrations section

### DIFF
--- a/Source/SuperOffice.DocsNext/ClientApp/src/content.config.ts
+++ b/Source/SuperOffice.DocsNext/ClientApp/src/content.config.ts
@@ -23,6 +23,17 @@ const enDocs = defineCollection({
   schema: DocsSchema,
 });
 
+const integrationDocs = defineCollection({
+  loader: glob({
+    pattern: partialBuild ? [] : [
+      "**/*.md",
+      "!**/includes/**",
+    ],
+    base: "external-content/superoffice-docs/integrations"
+  }),
+  schema: DocsSchema,
+});
+
 const apiDocs = defineCollection({
   loader: glob({
     pattern: partialBuild ? [] : [
@@ -155,6 +166,7 @@ const tocFiles = defineCollection({
     pattern: [
       "contribution/**/toc.yml",
       "superoffice-docs/docs/**/toc.yml",
+      "superoffice-docs/integrations/**/toc.yml",
       "superoffice-docs/release-notes/**/toc.yml",
     ],
     base: "./external-content",
@@ -166,6 +178,7 @@ const landingPages = defineCollection({
   loader: glob({
     pattern: [
       "contribution/**/*.yml",
+      "superoffice-docs/integrations/*.yml",
       "superoffice-docs/docs/**/*.yml",
       "!**/toc.yml",
       "!**/reference/**",   // Because CRMScript.Event.Trigger.yml isn't a valid landing page
@@ -186,6 +199,7 @@ export const collections = {
   "api-docs": apiDocs,
   "crmscript": CRMScript,
   "nsscripting": NSScriptingRef,
+  "integration-docs": integrationDocs,
   contribute: contribution,
   "release-notes": releaseNotes,
   cats: landingPages,

--- a/Source/SuperOffice.DocsNext/ClientApp/src/data/navigation.ts
+++ b/Source/SuperOffice.DocsNext/ClientApp/src/data/navigation.ts
@@ -1,6 +1,3 @@
-const base = import.meta.env.BASE_URL;
-
-
 export const headerData = {
   links: [
     {
@@ -8,41 +5,8 @@ export const headerData = {
       href: "en/learn"
     },
     {
-      text: 'Areas',
-      links: [
-        {
-          text: 'Company',
-          href: 'en/company',
-        },
-        {
-          text: 'Contact',
-          href: 'en/contact',
-        },
-        {
-          text: 'Diary',
-          href: 'en/diary',
-        },
-        {
-          text: 'Document',
-          href: 'en/document',
-        },
-        {
-          text: 'Email',
-          href: 'en/email',
-        },
-        {
-          text: 'Project',
-          href: 'en/project',
-        },
-        {
-          text: 'Request',
-          href: 'en/request',
-        },
-        {
-          text: 'Sale',
-          href: 'en/sale',
-        },
-      ],
+      text: 'Integrations',
+      href: "integrations"
     },
     {
       text: 'CRM Online',

--- a/Source/SuperOffice.DocsNext/ClientApp/src/pages/integrations/[...slug].astro
+++ b/Source/SuperOffice.DocsNext/ClientApp/src/pages/integrations/[...slug].astro
@@ -1,0 +1,37 @@
+---
+import { render } from "astro:content";
+import { getCollection } from "astro:content";
+import { stripFilePathAndExtension } from "@utils/slugUtils";
+import { getTocByPath } from "@utils/tocUtils";
+import ContentLayout from "@layouts/ContentLayout.astro";
+
+const tocData = await getTocByPath('superoffice-docs/integrations');
+
+export async function getStaticPaths() {
+  const docEntries = await getCollection("integration-docs");
+  const referencePath = "superoffice-docs/integrations" as const;
+
+  const paths = docEntries.map((entry) => {
+    const slug = stripFilePathAndExtension(entry.filePath!, referencePath);
+
+    return {
+      params: { slug },
+      props: { entry }
+    };
+  });
+
+  return paths;
+}
+
+const { entry } = Astro.props;
+const { Content, headings } = await render(entry);
+---
+
+<ContentLayout
+  headings={headings}
+  entry={entry}
+  toc={tocData}
+  TOCBasePath="integrations"
+>
+  {Content && <Content />}
+</ContentLayout

--- a/Source/SuperOffice.DocsNext/ClientApp/src/pages/integrations/index.astro
+++ b/Source/SuperOffice.DocsNext/ClientApp/src/pages/integrations/index.astro
@@ -1,0 +1,35 @@
+---
+import { getEntry, getCollection, type CollectionEntry } from "astro:content";
+import { getTableOfContentsFromCollection } from "@utils/tocUtils";
+import SubCategoryLandingLayout from "@layouts/SubCategoryLandingLayout.astro";
+
+type SubCategoryDataType = Extract<
+  CollectionEntry<"cats">["data"],
+  { YamlMime: "SubCategory" }
+>;
+
+const collectionPath = "superoffice-docs/integrations" as const;
+
+// This route supports only the SubCategory YAML at integrations/index.yml.
+// It is a special case since we have an index.yml at the root of the repo/collection. 
+const page = await getEntry("cats", collectionPath);
+if (!page) throw new Error("Missing superoffice-docs/integrations/index.yml");
+
+const CategoryData = page.data as SubCategoryDataType;
+
+// Build ToC for the sidebar
+const tocEntries = await getCollection("toc", (entry) =>
+  entry.id.startsWith(collectionPath)
+);
+
+const ToCData = await getTableOfContentsFromCollection(tocEntries, collectionPath);
+
+export const prerender = true;
+---
+
+<SubCategoryLandingLayout
+  lang="en"
+  baseSlug="integrations"
+  data={CategoryData}
+  ToCData={ToCData}
+/>


### PR DESCRIPTION
- Set up the newly introduced Integrations section, including subcategory page, TOC, and content pages.
- Replaced 'Areas' with 'Integrations' in Header

This PR resolves #289, resolves #290, resolves #291, resolves #292 user stories, and closes #288 feature issue, except for acceptance criteria related to Breadcrumbs and Search.



