### PR TITLE
cicd: stopped triggering older GitHub actions workflow automatically

### DIFF
--- a/.github/workflows/main_docs-next.yml
+++ b/.github/workflows/main_docs-next.yml
@@ -1,11 +1,5 @@
 name: Build and deploy ASP.Net Core app to Azure Web App - docs-next
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- removed automatic triggers on main_docs-next.yml workflow

(This workflow was used to deploy directly into an Azure App Service prior to the current Azure pipeline.) 