### PR TITLE
fix: updated file extension rewriting logic

### DIFF
--- a/Source/SuperOffice.DocsNext/Program.cs
+++ b/Source/SuperOffice.DocsNext/Program.cs
@@ -107,8 +107,10 @@ else
     var rewriteOptions = new RewriteOptions()
         // Redirect /something.html -> /something (permanent redirect)
         .AddRedirect(@"^(.*)\.html$", "$1", statusCode: 301)
+        .AddRewrite(@"^$", "index.html", skipRemainingRules: true)
         // Rewrite /something -> /something.html (internal rewrite)
-        .AddRewrite(@"^([^.]+)$", "$1.html", skipRemainingRules: true);
+        // But avoids rewriting known static file types
+        .AddRewrite(@"^(?!.*\.(?:js|css|png|jpg|jpeg|gif|svg|ico|json|txt|xml|map)$)(.*)$", "$1.html", skipRemainingRules: true);
 
     app.UseWhen(
         context => !context.Request.Path.StartsWithSegments("/api"),


### PR DESCRIPTION
- Updated URL's file extension rewriting login on .NET
 
Redirect /something.html -> /something (permanent redirect)
Rewrite /something -> /something.html (internal rewrite) (But avoid rewriting known static file types)