### PR TITLE
feat: updated build format and removed trailing slash in config

### DIFF
--- a/Source/SuperOffice.DocsNext/ClientApp/astro.config.mjs
+++ b/Source/SuperOffice.DocsNext/ClientApp/astro.config.mjs
@@ -118,10 +118,10 @@ export default defineConfig({
   },
 
   build: {
-    format: "preserve",
+    format: "file",
   },
   logLevel: process.env.CI ? 'error' : 'info',
   site: "https://app-superoffice-docs-dev.azurewebsites.net/",
   // base: "/",
-  trailingSlash: "never",
+  // trailingSlash: "never",
 });


### PR DESCRIPTION
- Updated build format in Astro to be `file`
Astro will generate an HTML file named for each page route. 
e.g. src/pages/about.astro and src/pages/about/index.astro both build the file /about.html 

- Removed trialing slash configuration to make it fall back to the default `ignore` state
It makes URLs match regardless of whether a trailing ”/” exists. Requests for “/about” and “/about/” will both match the same route. 
(Although this works from Astro, further changes need to be made in .NET routing to allow this)