### PR TITLE
fix: updated resolveRelativeFilePath to remove html from url

### DIFF
--- a/Source/SuperOffice.DocsNext/ClientApp/src/utils/slugUtils.ts
+++ b/Source/SuperOffice.DocsNext/ClientApp/src/utils/slugUtils.ts
@@ -173,6 +173,6 @@ export function resolveRelativeFilePath(currentPath: string, filepath: string): 
     return filepath
   }
   else {
-    return `${currentPath.split("/").pop()}/${trimFileExtension(filepath).replace("/index", "")}`
+    return `${currentPath.split("/").pop()?.replace(/\.html$/, "")}/${trimFileExtension(filepath).replace(/\/index$/, "")}`
   }
 }


### PR DESCRIPTION
- Updated resolveRelativeFilePath to remove .html from hyperlinks

Previously, instead of `[domain]/en/api/overview`, the generated link was `[domain]/en/api.html/overview`.
This was caused due to changing the build format to be file-based in Astro.
